### PR TITLE
feat(gateway): mesh peering across nodes sharing a central database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,14 @@ jobs:
       - name: Run tests
         run: make test
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: build/coverage.out
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ test: generate
 		IP="$$(docker inspect --format '{{ range .NetworkSettings.Networks }}{{ .IPAddress }}{{ end }}' $${CONTAINER})"; \
 		export GATEWAYSSHD_TEST_DATABASE_HOST="$${IP}"; \
 	fi; \
-	gotestsum --format testname -- -mod=readonly -race -cover -coverprofile=${BUILD_DIR}/coverage.out ./...; \
+	gotestsum --format testname -- -mod=readonly -race -coverpkg=./... -coverprofile=${BUILD_DIR}/coverage.out ./...; \
 	go tool cover -html=${BUILD_DIR}/coverage.out -o ${BUILD_DIR}/coverage.html; \
 	go tool cover -func=${BUILD_DIR}/coverage.out
 

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ test: generate
 		IP="$$(docker inspect --format '{{ range .NetworkSettings.Networks }}{{ .IPAddress }}{{ end }}' $${CONTAINER})"; \
 		export GATEWAYSSHD_TEST_DATABASE_HOST="$${IP}"; \
 	fi; \
-	gotestsum --format testname -- -mod=readonly -cover -coverprofile=${BUILD_DIR}/coverage.out ./...; \
+	gotestsum --format testname -- -mod=readonly -race -cover -coverprofile=${BUILD_DIR}/coverage.out ./...; \
 	go tool cover -html=${BUILD_DIR}/coverage.out -o ${BUILD_DIR}/coverage.html; \
 	go tool cover -func=${BUILD_DIR}/coverage.out
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ users, their reported status, and their geolocation in postgres.
   screenshots that are stored per user and served over the HTTP API.
 - **HTTP API** — `/api/user`, `/api/user/{id}`, `/api/user/{id}/screenshot`
   for dashboards and monitoring.
+- **SOCKS5 and HTTP proxies** (optional) — expose a SOCKS5 or HTTP
+  forward-proxy port so any client can reach exposed services by name
+  (`service.username`), the same reachability as an `ssh -D` dynamic
+  forward. Disabled by default; see the security note below.
 - **GeoIP** — optionally resolves each user's location from a MaxMind
   database.
 - **Mesh peering** — multiple gateway instances share one postgres database
@@ -133,6 +137,35 @@ gatewaysshd> exit
 `status`, `listUsers`, and `getUser` require the `permit-port-forwarding`
 certificate extension; `kickUser` additionally requires the user to be marked
 as an administrator in the database.
+
+## SOCKS5 and HTTP proxies
+
+Optionally, the gateway can expose forward proxies so clients that are not
+SSH tunnels can still reach exposed services by name. This is the equivalent
+of `ssh -D`: the proxy resolves `service.username` (locally or across the
+mesh) and bridges to it.
+
+```
+$ gatewaysshd \
+    ... \
+    --listen-socks 127.0.0.1:1080 \
+    --listen-http-proxy 127.0.0.1:8080
+```
+
+Then, for a service `web` exposed by user `alice`:
+
+```
+$ curl --socks5-hostname 127.0.0.1:1080 http://web.alice/
+$ curl --proxy http://127.0.0.1:8080 http://web.alice/
+```
+
+The HTTP proxy supports both `CONNECT` (tunneling arbitrary TCP) and
+absolute-form requests (plain HTTP forwarding).
+
+> **Security:** both proxies are **unauthenticated** — anyone who can reach
+> the proxy port can reach any exposed service, bypassing SSH certificate
+> auth. They are disabled by default; only enable them bound to a trusted
+> network (e.g. `127.0.0.1` or a private interface).
 
 ## Mesh peering
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # gatewaysshd
 
 [![CI](https://github.com/ziyan/gatewaysshd/actions/workflows/ci.yml/badge.svg)](https://github.com/ziyan/gatewaysshd/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/ziyan/gatewaysshd/branch/master/graph/badge.svg)](https://codecov.io/gh/ziyan/gatewaysshd)
 [![Release](https://img.shields.io/github/v/release/ziyan/gatewaysshd)](https://github.com/ziyan/gatewaysshd/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
@@ -52,6 +53,11 @@ users, their reported status, and their geolocation in postgres.
   for dashboards and monitoring.
 - **GeoIP** — optionally resolves each user's location from a MaxMind
   database.
+- **Mesh peering** — multiple gateway instances share one postgres database
+  and form a mesh, so a user on one node can tunnel to a user on another
+  node over the same SSH service port. Inter-node trust uses a separate peer
+  certificate authority layered on top of each node's existing user CA, so
+  existing single-node deployments keep their user-facing CA unchanged.
 - **Hardened crypto defaults** — insecure key exchanges, ciphers, and MACs
   are disabled out of the box.
 
@@ -127,6 +133,43 @@ gatewaysshd> exit
 `status`, `listUsers`, and `getUser` require the `permit-port-forwarding`
 certificate extension; `kickUser` additionally requires the user to be marked
 as an administrator in the database.
+
+## Mesh peering
+
+Several gateway instances can share a single postgres database and form a
+mesh. When a user connects to any node, the node it landed on is recorded on
+the user record. When another user asks to tunnel to `service.username`, the
+node resolves which node that user is on and forwards the tunnel to that node
+over an outbound peer connection — reusing the same SSH service port, no
+extra listener.
+
+Inter-node trust is a **separate peer certificate authority**, layered on top
+of each node's existing user CA. Peer nodes authenticate as the reserved user
+`peer` with a certificate signed by the peer CA (key id = node id); those
+certificates are checked only against `--peer-ca-public-key` and never grant
+user capabilities. Existing single-node deployments keep their user CA, host
+key, and service port unchanged — mesh is enabled purely by adding node
+flags:
+
+```
+$ gatewaysshd \
+    ... \
+    --node-id node-us \
+    --node-address gateway-us.example.com:2020 \
+    --node-certificate id_rsa.node-us-cert.pub \
+    --peer-ca-public-key id_rsa.peer-ca.pub
+```
+
+Nodes without direct database access can reach the central postgres through a
+peer node's SSH service port instead of a separate connection:
+
+```
+$ gatewaysshd \
+    ... \
+    --postgres-peer gateway-us.example.com:2020 \
+    --postgres-peer-host-public-key gateway-us.pub \
+    --node-certificate id_rsa.node-jp-cert.pub
+```
 
 ## Development
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -28,11 +28,11 @@ const PeerUser = "peer"
 
 type Settings struct {
 	// certificate authorities trusted for regular user certificates
-	CaPublicKeys []ssh.PublicKey
+	CAPublicKeys []ssh.PublicKey
 
 	// certificate authorities trusted for peer node certificates, empty
 	// disables inbound peer connections
-	PeerCaPublicKeys []ssh.PublicKey
+	PeerCAPublicKeys []ssh.PublicKey
 
 	// id of this node, recorded on users at auth time for mesh tunneling
 	NodeID string
@@ -71,7 +71,7 @@ func (self *authenticator) authenticate(meta ssh.ConnMetadata, publicKey ssh.Pub
 	// check certificate
 	certificateChecker := &ssh.CertChecker{
 		IsUserAuthority: func(publicKey ssh.PublicKey) bool {
-			for _, caPublicKey := range self.settings.CaPublicKeys {
+			for _, caPublicKey := range self.settings.CAPublicKeys {
 				if bytes.Equal(caPublicKey.Marshal(), publicKey.Marshal()) {
 					return true
 				}
@@ -123,14 +123,14 @@ func (self *authenticator) authenticate(meta ssh.ConnMetadata, publicKey ssh.Pub
 // its key id identifies the node. Permissions are built fresh so certificate
 // extensions never grant user-level capabilities.
 func (self *authenticator) authenticatePeer(meta ssh.ConnMetadata, publicKey ssh.PublicKey) (*ssh.Permissions, error) {
-	if len(self.settings.PeerCaPublicKeys) == 0 {
+	if len(self.settings.PeerCAPublicKeys) == 0 {
 		log.Warningf("rejected peer connection from %s: no peer certificate authority configured", meta.RemoteAddr())
 		return nil, ErrInvalidCredentials
 	}
 
 	certificateChecker := &ssh.CertChecker{
 		IsUserAuthority: func(publicKey ssh.PublicKey) bool {
-			for _, caPublicKey := range self.settings.PeerCaPublicKeys {
+			for _, caPublicKey := range self.settings.PeerCAPublicKeys {
 				if bytes.Equal(caPublicKey.Marshal(), publicKey.Marshal()) {
 					return true
 				}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -87,6 +87,12 @@ func (self *authenticator) authenticate(meta ssh.ConnMetadata, publicKey ssh.Pub
 		return nil, err
 	}
 
+	// peer status must come only from authenticatePeer, never from a user
+	// certificate extension: the user certificate authority must not be able
+	// to grant node/peer capabilities.
+	delete(permissions.Extensions, "peer")
+	delete(permissions.Extensions, "identity")
+
 	// update user in database
 	user, err := self.database.PutUser(context.Background(), meta.User(), func(model *db.User) error {
 		model.IP = ip.String()

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -20,11 +20,31 @@ var (
 	ErrInvalidCredentials = errors.New("auth: invalid credentials")
 )
 
-func NewConfig(database db.Database, caPublicKeys []ssh.PublicKey, geoipDatabase string) (*ssh.ServerConfig, error) {
+// PeerUser is the reserved username peer nodes authenticate with. Certificates
+// presented for this user are checked against the peer certificate authorities
+// instead of the user-facing ones, so inter-node trust can be layered on top of
+// existing deployments without touching their user certificate authority.
+const PeerUser = "peer"
+
+type Settings struct {
+	// certificate authorities trusted for regular user certificates
+	CaPublicKeys []ssh.PublicKey
+
+	// certificate authorities trusted for peer node certificates, empty
+	// disables inbound peer connections
+	PeerCaPublicKeys []ssh.PublicKey
+
+	// id of this node, recorded on users at auth time for mesh tunneling
+	NodeID string
+
+	// path to the geoip database file
+	GeoipDatabase string
+}
+
+func NewConfig(database db.Database, settings *Settings) (*ssh.ServerConfig, error) {
 	authenticator := &authenticator{
-		database:      database,
-		caPublicKeys:  caPublicKeys,
-		geoipDatabase: geoipDatabase,
+		database: database,
+		settings: settings,
 	}
 	config := &ssh.ServerConfig{
 		PublicKeyCallback: authenticator.authenticate,
@@ -34,12 +54,16 @@ func NewConfig(database db.Database, caPublicKeys []ssh.PublicKey, geoipDatabase
 }
 
 type authenticator struct {
-	database      db.Database
-	caPublicKeys  []ssh.PublicKey
-	geoipDatabase string
+	database db.Database
+	settings *Settings
 }
 
 func (self *authenticator) authenticate(meta ssh.ConnMetadata, publicKey ssh.PublicKey) (*ssh.Permissions, error) {
+	// peer nodes use a reserved username and a separate certificate authority
+	if meta.User() == PeerUser {
+		return self.authenticatePeer(meta, publicKey)
+	}
+
 	// lookup location
 	ip := meta.RemoteAddr().(*net.TCPAddr).AddrPort().Addr()
 	location := self.lookupLocation(ip)
@@ -47,7 +71,7 @@ func (self *authenticator) authenticate(meta ssh.ConnMetadata, publicKey ssh.Pub
 	// check certificate
 	certificateChecker := &ssh.CertChecker{
 		IsUserAuthority: func(publicKey ssh.PublicKey) bool {
-			for _, caPublicKey := range self.caPublicKeys {
+			for _, caPublicKey := range self.settings.CaPublicKeys {
 				if bytes.Equal(caPublicKey.Marshal(), publicKey.Marshal()) {
 					return true
 				}
@@ -67,6 +91,7 @@ func (self *authenticator) authenticate(meta ssh.ConnMetadata, publicKey ssh.Pub
 	user, err := self.database.PutUser(context.Background(), meta.User(), func(model *db.User) error {
 		model.IP = ip.String()
 		model.Location = location
+		model.NodeID = self.settings.NodeID
 		return nil
 	})
 	if err != nil {
@@ -87,9 +112,48 @@ func (self *authenticator) authenticate(meta ssh.ConnMetadata, publicKey ssh.Pub
 	return permissions, nil
 }
 
+// authenticatePeer validates a peer node certificate against the peer
+// certificate authorities. The certificate must carry the "peer" principal and
+// its key id identifies the node. Permissions are built fresh so certificate
+// extensions never grant user-level capabilities.
+func (self *authenticator) authenticatePeer(meta ssh.ConnMetadata, publicKey ssh.PublicKey) (*ssh.Permissions, error) {
+	if len(self.settings.PeerCaPublicKeys) == 0 {
+		log.Warningf("rejected peer connection from %s: no peer certificate authority configured", meta.RemoteAddr())
+		return nil, ErrInvalidCredentials
+	}
+
+	certificateChecker := &ssh.CertChecker{
+		IsUserAuthority: func(publicKey ssh.PublicKey) bool {
+			for _, caPublicKey := range self.settings.PeerCaPublicKeys {
+				if bytes.Equal(caPublicKey.Marshal(), publicKey.Marshal()) {
+					return true
+				}
+			}
+			log.Warningf("unknown peer authority: %v", publicKey)
+			return false
+		},
+	}
+	if _, err := certificateChecker.Authenticate(meta, publicKey); err != nil {
+		return nil, err
+	}
+
+	certificate, ok := publicKey.(*ssh.Certificate)
+	if !ok || certificate.KeyId == "" {
+		return nil, ErrInvalidCredentials
+	}
+
+	log.Infof("successful peer authentication, node = %s, remote = %s", certificate.KeyId, meta.RemoteAddr())
+	return &ssh.Permissions{
+		Extensions: map[string]string{
+			"peer":     "",
+			"identity": certificate.KeyId,
+		},
+	}, nil
+}
+
 func (self *authenticator) lookupLocation(ip netip.Addr) db.Location {
 	var location db.Location
-	reader, err := geoip2.Open(self.geoipDatabase)
+	reader, err := geoip2.Open(self.settings.GeoipDatabase)
 	if err != nil {
 		return location
 	}

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -89,24 +90,96 @@ var flags = []cli.Flag{
 		Value: "gatewaysshd",
 		Usage: "postgres database name",
 	},
+	&cli.StringFlag{
+		Name:  "postgres-sslmode",
+		Value: "disable",
+		Usage: "postgres sslmode (disable, require, verify-ca, verify-full)",
+	},
+	&cli.StringFlag{
+		Name:  "postgres-peer",
+		Value: "",
+		Usage: "peer node ssh address to tunnel postgres through, empty means direct connection",
+	},
+	&cli.StringFlag{
+		Name:  "postgres-peer-host-public-key",
+		Value: "",
+		Usage: "path to the pinned host public key of the postgres peer, required with postgres-peer",
+	},
+	&cli.StringFlag{
+		Name:  "node-id",
+		Value: "",
+		Usage: "unique id of this node in the mesh, empty disables node peering",
+	},
+	&cli.StringFlag{
+		Name:  "node-address",
+		Value: "",
+		Usage: "ssh address where peer nodes can reach this node, empty means not dialable",
+	},
+	&cli.StringFlag{
+		Name:  "node-certificate",
+		Value: "",
+		Usage: "path to the node certificate for the host private key, signed by the peer certificate authority with the \"peer\" principal, empty disables outbound peering",
+	},
+	&cli.StringFlag{
+		Name:  "peer-ca-public-key",
+		Value: "",
+		Usage: "path to certificate authority public keys trusted for inbound peer nodes, empty rejects peer connections",
+	},
 }
 
-func parseCaPublicKeys(command *cli.Command) ([]ssh.PublicKey, error) {
-	// get the keys
-	caPublicKeyRaw, err := os.ReadFile(command.String("ca-public-key"))
+// parsePublicKeys reads one or more public keys in authorized key format
+func parsePublicKeys(path string) ([]ssh.PublicKey, error) {
+	raw, err := os.ReadFile(path) // #nosec G304 - operator-supplied key path
 	if err != nil {
 		return nil, err
 	}
-	var caPublicKeys []ssh.PublicKey
-	for len(caPublicKeyRaw) > 0 {
-		caPublicKey, _, _, rest, err := ssh.ParseAuthorizedKey(caPublicKeyRaw)
+	var publicKeys []ssh.PublicKey
+	for len(raw) > 0 {
+		publicKey, _, _, rest, err := ssh.ParseAuthorizedKey(raw)
 		if err != nil {
 			return nil, err
 		}
-		caPublicKeys = append(caPublicKeys, caPublicKey)
-		caPublicKeyRaw = rest
+		publicKeys = append(publicKeys, publicKey)
+		raw = rest
 	}
-	return caPublicKeys, nil
+	return publicKeys, nil
+}
+
+// parseNodeSigner builds the signer used to authenticate to other nodes, from
+// the host private key and the node certificate signed by the peer
+// certificate authority
+func parseNodeSigner(command *cli.Command) (ssh.Signer, error) {
+	certificatePath := command.String("node-certificate")
+	if certificatePath == "" {
+		return nil, nil
+	}
+
+	hostPrivateKeyRaw, err := os.ReadFile(command.String("host-private-key"))
+	if err != nil {
+		return nil, err
+	}
+	hostPrivateKey, err := ssh.ParsePrivateKey(hostPrivateKeyRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	certificateRaw, err := os.ReadFile(certificatePath) // #nosec G304 - operator-supplied cert path
+	if err != nil {
+		return nil, err
+	}
+	certificatePublicKey, _, _, _, err := ssh.ParseAuthorizedKey(certificateRaw)
+	if err != nil {
+		return nil, err
+	}
+	certificate, ok := certificatePublicKey.(*ssh.Certificate)
+	if !ok {
+		return nil, fmt.Errorf("cli: node certificate file %q does not contain a certificate", certificatePath)
+	}
+	return ssh.NewCertSigner(certificate, hostPrivateKey)
+}
+
+func parseCaPublicKeys(command *cli.Command) ([]ssh.PublicKey, error) {
+	return parsePublicKeys(command.String("ca-public-key"))
 }
 
 func parseHostSigner(command *cli.Command) (ssh.Signer, error) {

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -36,6 +36,16 @@ var flags = []cli.Flag{
 		Usage: "http listen endpoint",
 	},
 	&cli.StringFlag{
+		Name:  "listen-socks",
+		Value: "",
+		Usage: "optional socks5 proxy listen endpoint, reaches any exposed service unauthenticated (like ssh -D), empty disables it",
+	},
+	&cli.StringFlag{
+		Name:  "listen-http-proxy",
+		Value: "",
+		Usage: "optional http forward proxy (CONNECT) listen endpoint, reaches any exposed service unauthenticated, empty disables it",
+	},
+	&cli.StringFlag{
 		Name:  "ca-public-key",
 		Value: "id_rsa.ca.pub",
 		Usage: "path to certificate authority public key",

--- a/cli/http_test.go
+++ b/cli/http_test.go
@@ -18,6 +18,8 @@ type fakeGateway struct {
 
 func (self *fakeGateway) Close()                            {}
 func (self *fakeGateway) HandleConnection(net.Conn)         {}
+func (self *fakeGateway) HandleSocksConnection(net.Conn)    {}
+func (self *fakeGateway) HTTPProxyHandler() http.Handler    { return nil }
 func (self *fakeGateway) ScavengeConnections(time.Duration) {}
 func (self *fakeGateway) ListUsers(context.Context) (interface{}, error) {
 	return map[string]interface{}{"users": []string{"alice"}}, nil

--- a/cli/run.go
+++ b/cli/run.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ziyan/gatewaysshd/gateway"
 	"github.com/ziyan/gatewaysshd/util/debugutil"
 	"github.com/ziyan/gatewaysshd/util/deferutil"
+	"github.com/ziyan/gatewaysshd/util/sshconfig"
 )
 
 func run(ctx context.Context, command *cli.Command) error {
@@ -49,6 +50,23 @@ func run(ctx context.Context, command *cli.Command) error {
 		return err
 	}
 
+	// optional peer certificate authority for inbound peer nodes
+	var peerCaPublicKeys []ssh.PublicKey
+	if path := command.String("peer-ca-public-key"); path != "" {
+		peerCaPublicKeys, err = parsePublicKeys(path)
+		if err != nil {
+			log.Errorf("failed to parse peer certificate authority public key from file \"%s\": %s", path, err)
+			return err
+		}
+	}
+
+	// optional node certificate for outbound peering
+	nodeSigner, err := parseNodeSigner(command)
+	if err != nil {
+		log.Errorf("failed to parse node certificate from file \"%s\": %s", command.String("node-certificate"), err)
+		return err
+	}
+
 	// ssh listener
 	log.Debugf("listening ssh endpoint: %s", command.String("listen-ssh"))
 	sshListener, err := net.Listen("tcp", command.String("listen-ssh"))
@@ -73,7 +91,28 @@ func run(ctx context.Context, command *cli.Command) error {
 	if pgPort > 65535 {
 		return fmt.Errorf("cli: postgres port %d is out of range (max 65535)", pgPort)
 	}
-	database, err := db.Open(command.String("postgres-host"), uint16(pgPort), command.String("postgres-user"), command.String("postgres-password"), command.String("postgres-dbname"))
+	databaseSettings := &db.Settings{
+		Host:         command.String("postgres-host"),
+		Port:         uint16(pgPort),
+		User:         command.String("postgres-user"),
+		Password:     command.String("postgres-password"),
+		DatabaseName: command.String("postgres-dbname"),
+		SSLMode:      command.String("postgres-sslmode"),
+	}
+	if peerAddress := command.String("postgres-peer"); peerAddress != "" {
+		if nodeSigner == nil {
+			return fmt.Errorf("cli: postgres-peer requires node-certificate")
+		}
+		pinnedHostKeys, err := parsePublicKeys(command.String("postgres-peer-host-public-key"))
+		if err != nil || len(pinnedHostKeys) == 0 {
+			log.Errorf("failed to parse postgres peer host public key from file \"%s\": %v", command.String("postgres-peer-host-public-key"), err)
+			return fmt.Errorf("cli: postgres-peer requires postgres-peer-host-public-key")
+		}
+		databaseSettings.PeerAddress = peerAddress
+		databaseSettings.PeerSigner = nodeSigner
+		databaseSettings.PeerHostPublicKey = pinnedHostKeys[0]
+	}
+	database, err := db.Open(databaseSettings)
 	if err != nil {
 		log.Errorf("failed to open database: %s", err)
 		return err
@@ -89,41 +128,41 @@ func run(ctx context.Context, command *cli.Command) error {
 	}
 
 	// create ssh auth config
-	sshConfig, err := auth.NewConfig(database, caPublicKeys, command.String("geoip-database"))
+	sshConfig, err := auth.NewConfig(database, &auth.Settings{
+		CaPublicKeys:     caPublicKeys,
+		PeerCaPublicKeys: peerCaPublicKeys,
+		NodeID:           command.String("node-id"),
+		GeoipDatabase:    command.String("geoip-database"),
+	})
 	if err != nil {
 		log.Errorf("failed to create ssh config: %s", err)
 		return err
 	}
-	// remove insecure key exchanges from the default list of key exchanges (ssh.defaultKexAlgos)
-	sshConfig.KeyExchanges = []string{
-		ssh.KeyExchangeCurve25519,
-		ssh.KeyExchangeECDHP256,
-		ssh.KeyExchangeECDHP384,
-		ssh.KeyExchangeECDHP521,
-		ssh.KeyExchangeDH14SHA256,
-	}
-	// remove insecure ciphers from the default list of ciphers (ssh.defaultCiphers)
-	sshConfig.Ciphers = []string{
-		ssh.CipherAES128GCM,
-		ssh.CipherAES256GCM,
-		ssh.CipherAES128CTR,
-		ssh.CipherAES192CTR,
-		ssh.CipherAES256CTR,
-	}
-	// remove insecure MACs from the default list of MACs (ssh.defaultMACs)
-	sshConfig.MACs = []string{
-		ssh.HMACSHA256ETM,
-		ssh.HMACSHA512ETM,
-		ssh.HMACSHA256,
-		ssh.HMACSHA512,
-		ssh.HMACSHA1,
-	}
+	// remove insecure key exchanges, ciphers, and macs from the defaults
+	sshconfig.ApplySSHCryptoConfig(&sshConfig.Config)
 	sshConfig.ServerVersion = command.String("server-version")
 	sshConfig.AddHostKey(hostSigner)
 
+	// this node only bridges postgres for peers when it has direct access
+	postgresAddress := ""
+	if command.String("postgres-peer") == "" {
+		postgresAddress = fmt.Sprintf("%s:%d", command.String("postgres-host"), pgPort)
+	}
+
+	// host public key published for peer host key pinning
+	hostPublicKey := hostSigner.PublicKey()
+	if certificate, ok := hostPublicKey.(*ssh.Certificate); ok {
+		hostPublicKey = certificate.Key
+	}
+
 	// create gateway
 	gateway, err := gateway.Open(database, sshConfig, &gateway.Settings{
-		Version: command.Root().Version,
+		Version:         command.Root().Version,
+		NodeID:          command.String("node-id"),
+		NodeAddress:     command.String("node-address"),
+		HostPublicKey:   hostPublicKey,
+		NodeSigner:      nodeSigner,
+		PostgresAddress: postgresAddress,
 	})
 	if err != nil {
 		log.Errorf("failed to create ssh gateway: %s", err)

--- a/cli/run.go
+++ b/cli/run.go
@@ -129,8 +129,8 @@ func run(ctx context.Context, command *cli.Command) error {
 
 	// create ssh auth config
 	sshConfig, err := auth.NewConfig(database, &auth.Settings{
-		CaPublicKeys:     caPublicKeys,
-		PeerCaPublicKeys: peerCaPublicKeys,
+		CAPublicKeys:     caPublicKeys,
+		PeerCAPublicKeys: peerCaPublicKeys,
 		NodeID:           command.String("node-id"),
 		GeoipDatabase:    command.String("geoip-database"),
 	})

--- a/cli/run.go
+++ b/cli/run.go
@@ -86,6 +86,28 @@ func run(ctx context.Context, command *cli.Command) error {
 		}
 	}
 
+	// optional socks5 proxy listener
+	var socksListener net.Listener
+	if command.String("listen-socks") != "" {
+		log.Debugf("listening socks endpoint: %s", command.String("listen-socks"))
+		socksListener, err = net.Listen("tcp", command.String("listen-socks"))
+		if err != nil {
+			log.Errorf("failed to listen on %s: %s", command.String("listen-socks"), err)
+			return err
+		}
+	}
+
+	// optional http forward proxy listener
+	var httpProxyListener net.Listener
+	if command.String("listen-http-proxy") != "" {
+		log.Debugf("listening http proxy endpoint: %s", command.String("listen-http-proxy"))
+		httpProxyListener, err = net.Listen("tcp", command.String("listen-http-proxy"))
+		if err != nil {
+			log.Errorf("failed to listen on %s: %s", command.String("listen-http-proxy"), err)
+			return err
+		}
+	}
+
 	// open database
 	pgPort := command.Uint("postgres-port")
 	if pgPort > 65535 {
@@ -223,6 +245,58 @@ func run(ctx context.Context, command *cli.Command) error {
 		}()
 	}
 
+	// serve socks proxy
+	socksRunning := make(chan struct{})
+	if socksListener != nil {
+		waitGroup.Add(1)
+		go func() {
+			defer deferutil.Recover()
+			defer waitGroup.Done()
+			defer close(socksRunning)
+
+			log.Debugf("running and serving socks proxy")
+			for {
+				socket, err := socksListener.Accept()
+				if err != nil {
+					log.Errorf("failed to accept incoming socks connection: %s", err)
+					break
+				}
+				waitGroup.Add(1)
+				go func() {
+					defer deferutil.Recover()
+					defer waitGroup.Done()
+					gateway.HandleSocksConnection(socket)
+				}()
+			}
+
+			log.Debugf("stop serving socks proxy")
+		}()
+	}
+
+	// serve http forward proxy
+	var httpProxyServer *http.Server
+	httpProxyRunning := make(chan struct{})
+	if httpProxyListener != nil {
+		httpProxyServer = &http.Server{
+			Addr:              command.String("listen-http-proxy"),
+			Handler:           gateway.HTTPProxyHandler(),
+			ReadHeaderTimeout: 30 * time.Second,
+		}
+		waitGroup.Add(1)
+		go func() {
+			defer deferutil.Recover()
+			defer waitGroup.Done()
+			defer close(httpProxyRunning)
+
+			log.Debugf("running and serving http proxy")
+			if err := httpProxyServer.Serve(httpProxyListener); err != nil && err != http.ErrServerClosed {
+				log.Errorf("http proxy server exited with error: %s", err)
+			}
+
+			log.Debugf("stop serving http proxy")
+		}()
+	}
+
 	// wait till exit
 	signaling := make(chan os.Signal, 2)
 	signal.Notify(signaling, syscall.SIGINT, syscall.SIGTERM)
@@ -237,6 +311,10 @@ func run(ctx context.Context, command *cli.Command) error {
 		case <-sshRunning:
 			quit = true
 		case <-httpRunning:
+			quit = true
+		case <-socksRunning:
+			quit = true
+		case <-httpProxyRunning:
 			quit = true
 		case <-time.After(10 * time.Second):
 			gateway.ScavengeConnections(idleTimeout)
@@ -269,6 +347,28 @@ func run(ctx context.Context, command *cli.Command) error {
 			defer waitGroup.Done()
 			if err := httpServer.Shutdown(ctx); err != nil {
 				log.Errorf("failed to shutdown http server: %s", err)
+			}
+		}()
+	}
+
+	if socksListener != nil {
+		waitGroup.Add(1)
+		go func() {
+			defer deferutil.Recover()
+			defer waitGroup.Done()
+			if err := socksListener.Close(); err != nil {
+				log.Errorf("failed to close socks listener: %s", err)
+			}
+		}()
+	}
+
+	if httpProxyServer != nil {
+		waitGroup.Add(1)
+		go func() {
+			defer deferutil.Recover()
+			defer waitGroup.Done()
+			if err := httpProxyServer.Shutdown(ctx); err != nil {
+				log.Errorf("failed to shutdown http proxy server: %s", err)
 			}
 		}()
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -110,6 +110,17 @@ func Open(settings *Settings) (Database, error) {
 }
 
 func (self *database) Close() error {
+	// closing the pool closes every pooled connection, which for the peer
+	// tunnel mode closes the underlying ssh client via tunnelConn.Close
+	sqlDatabase, err := self.db.DB()
+	if err != nil {
+		return err
+	}
+	if err := sqlDatabase.Close(); err != nil {
+		return err
+	}
+	// wait for the per-tunnel request-draining goroutines to exit
+	self.waitGroup.Wait()
 	return nil
 }
 

--- a/db/db.go
+++ b/db/db.go
@@ -78,9 +78,12 @@ func Open(settings *Settings) (Database, error) {
 		if err != nil {
 			return nil, err
 		}
-		// the transport is the tunnel, but pgx still resolves the host
-		// before dialing, so it must be resolvable
-		config.Host = "localhost"
+		// the DialFunc tunnels every connection, so skip the real DNS lookup
+		// pgx would otherwise do for the configured host. keep config.Host
+		// untouched so it remains the TLS server name for verify-ca/verify-full.
+		config.LookupFunc = func(ctx context.Context, host string) ([]string, error) {
+			return []string{host}, nil
+		}
 		config.DialFunc = func(ctx context.Context, network, address string) (net.Conn, error) {
 			return dialPostgresViaPeer(settings.PeerAddress, settings.PeerSigner, settings.PeerHostPublicKey, &self.waitGroup)
 		}

--- a/db/db.go
+++ b/db/db.go
@@ -1,17 +1,20 @@
 // Database
 //
-// authorities - store certificate authorities, private key, hostname regex
-// group - store group, principal regex, principal validity
 // user - store user special attributes, such as non-ldap user, groups
-// certificates - store signed certificates, key by username/serial
+// node - store gateway nodes participating in the mesh
 package db
 
 import (
 	"context"
 	"fmt"
+	"net"
+	"sync"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/stdlib"
 	logging "github.com/op/go-logging"
+	"golang.org/x/crypto/ssh"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -29,15 +32,66 @@ type Database interface {
 	ListUsers(context.Context) ([]*User, error)
 	GetUser(context.Context, string) (*User, error)
 	PutUser(context.Context, string, func(*User) error) (*User, error)
+
+	ListNodes(context.Context) ([]*Node, error)
+	GetNode(context.Context, string) (*Node, error)
+	PutNode(context.Context, string, func(*Node) error) (*Node, error)
+}
+
+type Settings struct {
+	// postgres connection settings
+	Host         string
+	Port         uint16
+	User         string
+	Password     string
+	DatabaseName string
+	SSLMode      string
+
+	// optional peer tunnel settings, for reaching a remote postgres through
+	// a peer node's ssh service port instead of connecting directly
+	PeerAddress       string        // peer ssh address, empty = direct connection
+	PeerSigner        ssh.Signer    // node certificate signer, required if PeerAddress is set
+	PeerHostPublicKey ssh.PublicKey // pinned host public key of the peer, required if PeerAddress is set
 }
 
 type database struct {
-	db *gorm.DB
+	db        *gorm.DB
+	waitGroup sync.WaitGroup
 }
 
-func Open(host string, port uint16, user, password, databaseName string) (Database, error) {
-	connection := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable", host, port, user, password, databaseName)
-	db, err := gorm.Open(postgres.Open(connection), &gorm.Config{
+func Open(settings *Settings) (Database, error) {
+	self := &database{}
+
+	sslMode := settings.SSLMode
+	if sslMode == "" {
+		sslMode = "disable"
+	}
+	dsn := fmt.Sprintf(
+		"host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
+		settings.Host, settings.Port, settings.User, settings.Password, settings.DatabaseName, sslMode,
+	)
+
+	var dialector gorm.Dialector
+	if settings.PeerAddress != "" {
+		// tunnel postgres through a peer node's ssh service port
+		config, err := pgx.ParseConfig(dsn)
+		if err != nil {
+			return nil, err
+		}
+		// the transport is the tunnel, but pgx still resolves the host
+		// before dialing, so it must be resolvable
+		config.Host = "localhost"
+		config.DialFunc = func(ctx context.Context, network, address string) (net.Conn, error) {
+			return dialPostgresViaPeer(settings.PeerAddress, settings.PeerSigner, settings.PeerHostPublicKey, &self.waitGroup)
+		}
+		dialector = postgres.New(postgres.Config{
+			Conn: stdlib.OpenDB(*config),
+		})
+	} else {
+		dialector = postgres.Open(dsn)
+	}
+
+	db, err := gorm.Open(dialector, &gorm.Config{
 		Logger: logger.New(
 			&logWriter{},
 			logger.Config{
@@ -51,9 +105,7 @@ func Open(host string, port uint16, user, password, databaseName string) (Databa
 	if err != nil {
 		return nil, err
 	}
-	self := &database{
-		db: db.Debug(),
-	}
+	self.db = db.Debug()
 	return self, nil
 }
 

--- a/db/dbtest/dbtest.go
+++ b/db/dbtest/dbtest.go
@@ -108,6 +108,15 @@ func isTransientExecError(err error) bool {
 // database. The test is skipped when GATEWAYSSHD_TEST_DATABASE_HOST is not set.
 func AcquireDatabase(test *testing.T) (db.Database, func()) {
 	test.Helper()
+	database, _, release := AcquireDatabaseWithSettings(test)
+	return database, release
+}
+
+// AcquireDatabaseWithSettings is AcquireDatabase but also returns the
+// connection settings, so tests can open additional connections to the same
+// database (e.g. tunneled through a peer node).
+func AcquireDatabaseWithSettings(test *testing.T) (db.Database, *db.Settings, func()) {
+	test.Helper()
 
 	host := os.Getenv(TestDatabaseHostEnv)
 	if host == "" {
@@ -119,14 +128,21 @@ func AcquireDatabase(test *testing.T) (db.Database, func()) {
 	if err := execAdmin(host, fmt.Sprintf("CREATE DATABASE %q", databaseName)); err != nil {
 		test.Fatalf("failed to create test database: %s", err)
 	}
-	database, err := db.Open(host, testDatabasePort, testDatabaseUser, testDatabasePassword, databaseName)
+	settings := &db.Settings{
+		Host:         host,
+		Port:         testDatabasePort,
+		User:         testDatabaseUser,
+		Password:     testDatabasePassword,
+		DatabaseName: databaseName,
+	}
+	database, err := db.Open(settings)
 	if err != nil {
 		test.Fatalf("failed to open test database: %s", err)
 	}
 	if err := database.Migrate(context.Background()); err != nil {
 		test.Fatalf("failed to migrate test database: %s", err)
 	}
-	return database, func() {
+	return database, settings, func() {
 		if err := database.Close(); err != nil {
 			test.Fatalf("failed to close test database: %s", err)
 		}

--- a/db/migrations/0004_add_node.reverse.sql
+++ b/db/migrations/0004_add_node.reverse.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "node";

--- a/db/migrations/0004_add_node.sql
+++ b/db/migrations/0004_add_node.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS "node" (
+    "id" varchar(256),
+    "created_at" timestamp with time zone,
+    "modified_at" timestamp with time zone,
+    "address" varchar(256),
+    "host_public_key" text,
+    "online" boolean,
+    "online_at" timestamp with time zone,
+    PRIMARY KEY ("id")
+);

--- a/db/migrations/0005_add_user_node.reverse.sql
+++ b/db/migrations/0005_add_user_node.reverse.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" DROP COLUMN "node_id";

--- a/db/migrations/0005_add_user_node.sql
+++ b/db/migrations/0005_add_user_node.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "node_id" varchar(256);

--- a/db/models.go
+++ b/db/models.go
@@ -86,6 +86,9 @@ type User struct {
 	// whether the user account has been disabled
 	Disabled bool `json:"disabled,omitempty"`
 
+	// the node the user last connected to, used for mesh tunneling
+	NodeID string `json:"nodeId,omitempty"`
+
 	// whether the user is online, not saved in database
 	Online bool `json:"online,omitempty" gorm:"-"`
 
@@ -95,4 +98,30 @@ type User struct {
 
 func (self *User) TableName() string {
 	return "user"
+}
+
+// represents a gateway node participating in the mesh
+type Node struct {
+	ID string `json:"id,omitempty" gorm:"primary_key:true"`
+
+	// meta data
+	CreatedAt  time.Time `json:"createdAt,omitempty"`
+	ModifiedAt time.Time `json:"modifiedAt,omitempty"`
+
+	// address where peer nodes can reach this node
+	Address string `json:"address,omitempty"`
+
+	// host public key of this node in authorized key format, pinned by
+	// dialing peers to verify the remote host
+	HostPublicKey string `json:"hostPublicKey,omitempty"`
+
+	// whether the node is online
+	Online bool `json:"online,omitempty"`
+
+	// when the online status last changed
+	OnlineAt time.Time `json:"onlineAt,omitempty"`
+}
+
+func (self *Node) TableName() string {
+	return "node"
 }

--- a/db/nodes.go
+++ b/db/nodes.go
@@ -1,0 +1,83 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+func (self *database) ListNodes(ctx context.Context) ([]*Node, error) {
+	var results []*Node
+	if err := self.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var models []Node
+		if err := tx.Find(&models).Error; err != nil {
+			return err
+		}
+		results = make([]*Node, 0, len(models))
+		for index := range models {
+			results = append(results, &models[index])
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (self *database) GetNode(ctx context.Context, nodeId string) (*Node, error) {
+	var result *Node
+	if err := self.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var model Node
+		if err := tx.Where("id = ?", nodeId).First(&model).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil
+			}
+			return err
+		}
+		result = &model
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (self *database) PutNode(ctx context.Context, nodeId string, modifier func(*Node) error) (*Node, error) {
+	var result *Node
+	if err := self.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var create bool
+		var model Node
+		if err := tx.Where("id = ?", nodeId).First(&model).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				create = true
+			} else {
+				return err
+			}
+		}
+		if err := modifier(&model); err != nil {
+			return err
+		}
+		model.ID = nodeId
+		now := time.Now().In(time.Local)
+		if create {
+			model.CreatedAt = now
+		}
+		model.ModifiedAt = now
+		if create {
+			if err := tx.Create(&model).Error; err != nil {
+				return err
+			}
+		} else {
+			if err := tx.Save(&model).Error; err != nil {
+				return err
+			}
+		}
+		result = &model
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/db/nodes_integration_test.go
+++ b/db/nodes_integration_test.go
@@ -1,0 +1,65 @@
+package db_test
+
+import (
+	"testing"
+
+	"github.com/ziyan/gatewaysshd/db"
+	"github.com/ziyan/gatewaysshd/db/dbtest"
+)
+
+func TestPutNodeCreatesAndLists(t *testing.T) {
+	t.Parallel()
+	database, release := dbtest.AcquireDatabase(t)
+	defer release()
+
+	if _, err := database.PutNode(t.Context(), "node-a", func(node *db.Node) error {
+		node.Address = "127.0.0.1:2020"
+		node.HostPublicKey = "ssh-ed25519 AAAA..."
+		node.Online = true
+		return nil
+	}); err != nil {
+		t.Fatalf("failed to create node: %s", err)
+	}
+
+	node, err := database.GetNode(t.Context(), "node-a")
+	if err != nil {
+		t.Fatalf("failed to get node: %s", err)
+	}
+	if node == nil || node.Address != "127.0.0.1:2020" || !node.Online {
+		t.Fatalf("unexpected node: %+v", node)
+	}
+
+	// update marks it offline and preserves creation time
+	updated, err := database.PutNode(t.Context(), "node-a", func(node *db.Node) error {
+		node.Online = false
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to update node: %s", err)
+	}
+	if updated.Online {
+		t.Fatalf("expected node to be offline, got %+v", updated)
+	}
+
+	nodes, err := database.ListNodes(t.Context())
+	if err != nil {
+		t.Fatalf("failed to list nodes: %s", err)
+	}
+	if len(nodes) != 1 || nodes[0].ID != "node-a" {
+		t.Fatalf("unexpected nodes: %+v", nodes)
+	}
+}
+
+func TestGetNodeMissingReturnsNil(t *testing.T) {
+	t.Parallel()
+	database, release := dbtest.AcquireDatabase(t)
+	defer release()
+
+	node, err := database.GetNode(t.Context(), "missing")
+	if err != nil {
+		t.Fatalf("failed to get missing node: %s", err)
+	}
+	if node != nil {
+		t.Fatalf("expected nil, got %+v", node)
+	}
+}

--- a/db/ssh.go
+++ b/db/ssh.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"bytes"
 	"fmt"
 	"net"
 	"sync"
@@ -21,34 +20,10 @@ type tunnelData struct {
 	OriginPort    uint32
 }
 
-// checkPinnedHostKey accepts the remote host key when it, or the key embedded
-// in its certificate, matches the pinned public key. The peer's host
-// certificate is signed by that node's own certificate authority which this
-// node does not necessarily trust, so the key itself is pinned instead.
-func checkPinnedHostKey(pinned ssh.PublicKey) ssh.HostKeyCallback {
-	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
-		if certificate, ok := key.(*ssh.Certificate); ok {
-			key = certificate.Key
-		}
-		if !bytes.Equal(key.Marshal(), pinned.Marshal()) {
-			return fmt.Errorf("db: host key mismatch for peer %s", hostname)
-		}
-		return nil
-	}
-}
-
 // dialPostgresViaPeer creates a net.Conn to the remote postgres by opening a
 // direct-tcpip channel to "postgres:5432" over a peer node's ssh service port.
 func dialPostgresViaPeer(address string, signer ssh.Signer, pinnedHostKey ssh.PublicKey, waitGroup *sync.WaitGroup) (net.Conn, error) {
-	config := &ssh.ClientConfig{
-		User: "peer",
-		Auth: []ssh.AuthMethod{
-			ssh.PublicKeys(signer),
-		},
-		HostKeyCallback: checkPinnedHostKey(pinnedHostKey),
-		Timeout:         10 * time.Second,
-	}
-	sshconfig.ApplySSHCryptoConfig(&config.Config)
+	config := sshconfig.NewPeerClientConfig(signer, pinnedHostKey)
 
 	client, err := ssh.Dial("tcp", address, config)
 	if err != nil {

--- a/db/ssh.go
+++ b/db/ssh.go
@@ -1,0 +1,100 @@
+package db
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/ziyan/gatewaysshd/util/deferutil"
+	"github.com/ziyan/gatewaysshd/util/sshconfig"
+)
+
+// ssh tunnel data structure, must match gateway/utils.go
+type tunnelData struct {
+	Host          string
+	Port          uint32
+	OriginAddress string
+	OriginPort    uint32
+}
+
+// checkPinnedHostKey accepts the remote host key when it, or the key embedded
+// in its certificate, matches the pinned public key. The peer's host
+// certificate is signed by that node's own certificate authority which this
+// node does not necessarily trust, so the key itself is pinned instead.
+func checkPinnedHostKey(pinned ssh.PublicKey) ssh.HostKeyCallback {
+	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		if certificate, ok := key.(*ssh.Certificate); ok {
+			key = certificate.Key
+		}
+		if !bytes.Equal(key.Marshal(), pinned.Marshal()) {
+			return fmt.Errorf("db: host key mismatch for peer %s", hostname)
+		}
+		return nil
+	}
+}
+
+// dialPostgresViaPeer creates a net.Conn to the remote postgres by opening a
+// direct-tcpip channel to "postgres:5432" over a peer node's ssh service port.
+func dialPostgresViaPeer(address string, signer ssh.Signer, pinnedHostKey ssh.PublicKey, waitGroup *sync.WaitGroup) (net.Conn, error) {
+	config := &ssh.ClientConfig{
+		User: "peer",
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(signer),
+		},
+		HostKeyCallback: checkPinnedHostKey(pinnedHostKey),
+		Timeout:         10 * time.Second,
+	}
+	sshconfig.ApplySSHCryptoConfig(&config.Config)
+
+	client, err := ssh.Dial("tcp", address, config)
+	if err != nil {
+		return nil, fmt.Errorf("db: failed to dial peer: %w", err)
+	}
+
+	channel, requests, err := client.OpenChannel("direct-tcpip", ssh.Marshal(&tunnelData{
+		Host:          "postgres",
+		Port:          5432,
+		OriginAddress: "localhost",
+		OriginPort:    0,
+	}))
+	if err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("db: failed to open postgres tunnel: %w", err)
+	}
+
+	waitGroup.Add(1)
+	go func() {
+		defer deferutil.Recover()
+		defer waitGroup.Done()
+		ssh.DiscardRequests(requests)
+	}()
+
+	return &tunnelConn{
+		channel: channel,
+		client:  client,
+	}, nil
+}
+
+// tunnelConn implements net.Conn over an ssh channel
+type tunnelConn struct {
+	channel ssh.Channel
+	client  *ssh.Client
+}
+
+func (self *tunnelConn) Read(data []byte) (int, error)  { return self.channel.Read(data) }
+func (self *tunnelConn) Write(data []byte) (int, error) { return self.channel.Write(data) }
+
+func (self *tunnelConn) Close() error {
+	_ = self.channel.Close()
+	return self.client.Close()
+}
+
+func (self *tunnelConn) LocalAddr() net.Addr                       { return &net.TCPAddr{} }
+func (self *tunnelConn) RemoteAddr() net.Addr                      { return &net.TCPAddr{} }
+func (self *tunnelConn) SetDeadline(deadline time.Time) error      { return nil }
+func (self *tunnelConn) SetReadDeadline(deadline time.Time) error  { return nil }
+func (self *tunnelConn) SetWriteDeadline(deadline time.Time) error { return nil }

--- a/db/ssh.go
+++ b/db/ssh.go
@@ -68,6 +68,10 @@ func (self *tunnelConn) Close() error {
 	return self.client.Close()
 }
 
+// ssh channels do not support deadlines, so the deadline setters are no-ops.
+// query-level context timeouts therefore cannot interrupt in-flight I/O over
+// the tunnel; callers relying on them must set a connect timeout instead. This
+// matches the transport being an already-authenticated, encrypted ssh channel.
 func (self *tunnelConn) LocalAddr() net.Addr                       { return &net.TCPAddr{} }
 func (self *tunnelConn) RemoteAddr() net.Addr                      { return &net.TCPAddr{} }
 func (self *tunnelConn) SetDeadline(deadline time.Time) error      { return nil }

--- a/gateway/connection.go
+++ b/gateway/connection.go
@@ -38,6 +38,7 @@ type connection struct {
 	tunnelsClosed        uint64
 	services             map[string]map[uint16]bool
 	done                 chan struct{}
+	closeOnce            sync.Once
 	lock                 sync.Mutex
 	waitGroup            sync.WaitGroup
 	usage                *usageStats
@@ -82,10 +83,13 @@ func handleConnection(gateway *gateway, conn *ssh.ServerConn, channels <-chan ss
 		done:                 make(chan struct{}),
 	}
 	log.Infof("%s: new connection", self)
+
+	// take the waitGroup token before publishing the connection to the gateway,
+	// so a concurrent Close()/waitGroup.Wait() cannot race this Add
+	self.waitGroup.Add(1)
 	self.gateway.addConnection(self)
 
 	// handle requests and channels on this connection
-	self.waitGroup.Add(1)
 	go func() {
 		defer deferutil.Recover()
 		defer self.waitGroup.Done()
@@ -129,10 +133,13 @@ func (self *connection) String() string {
 	return fmt.Sprintf("connection(id=%q, remote=%q, user=%q)", self.id, self.remoteAddress, self.user)
 }
 
-// close the ssh connection
+// close the ssh connection. safe to call from multiple goroutines
+// (shutdown, scavenger, kickUser) concurrently.
 func (self *connection) close() {
 	defer self.waitGroup.Wait()
-	close(self.done)
+	self.closeOnce.Do(func() {
+		close(self.done)
+	})
 	log.Debugf("%s: connection closed", self)
 }
 
@@ -171,10 +178,7 @@ func (self *connection) deleteTunnel(closedTunnel *tunnel) {
 
 // returns the last used time of the connection
 func (self *connection) getUsedAt() time.Time {
-	self.lock.Lock()
-	defer self.lock.Unlock()
-
-	return self.usage.usedAt
+	return self.usage.getUsedAt()
 }
 
 // returns the list of services this connection advertises
@@ -271,11 +275,11 @@ func (self *connection) gatherStatus() *connectionStatus {
 		TunnelsOpened:        self.tunnelsOpened,
 		TunnelsClosed:        self.tunnelsClosed,
 		CreatedAt:            self.usage.createdAt,
-		UsedAt:               self.usage.usedAt,
+		UsedAt:               self.usage.getUsedAt(),
 		UpTime:               uint64(time.Since(self.usage.createdAt).Seconds()),
-		IdleTime:             uint64(time.Since(self.usage.usedAt).Seconds()),
-		BytesRead:            self.usage.bytesRead,
-		BytesWritten:         self.usage.bytesWritten,
+		IdleTime:             uint64(time.Since(self.usage.getUsedAt()).Seconds()),
+		BytesRead:            self.usage.getBytesRead(),
+		BytesWritten:         self.usage.getBytesWritten(),
 		Services:             services,
 	}
 }
@@ -382,11 +386,13 @@ func (self *connection) handleChannel(newChannel ssh.NewChannel) error {
 	switch newChannel.ChannelType() {
 	case "session":
 		// peer connections have no user and must not reach the session
-		// handlers, which would otherwise write an empty-named user row
+		// handlers, which would otherwise write an empty-named user row.
+		// leave err nil so it takes the leak-free reject path below.
 		if self.nodeId != "" {
-			return newChannel.Reject(ssh.Prohibited, "sessions not allowed on peer connections")
+			ok, rejection, message, err = false, ssh.Prohibited, "sessions not allowed on peer connections", nil
+		} else {
+			ok, rejection, message, err = self.handleSessionChannel(newChannel)
 		}
-		ok, rejection, message, err = self.handleSessionChannel(newChannel)
 	case "direct-tcpip":
 		ok, rejection, message, err = self.handleTunnelChannel(newChannel)
 	}
@@ -449,8 +455,9 @@ func (self *connection) handleTunnelChannel(newChannel ssh.NewChannel) (bool, ss
 		return false, ssh.UnknownChannelType, "failed to decode extra data", err
 	}
 
-	// peer nodes may tunnel to the local postgres database
-	if data.Host == "postgres" && data.Port == 5432 {
+	// peer nodes may tunnel to the local postgres database; gate on the peer
+	// connection so a regular user's service named "postgres" is not shadowed
+	if self.nodeId != "" && data.Host == "postgres" && data.Port == 5432 {
 		return self.handlePostgresChannel(newChannel)
 	}
 

--- a/gateway/connection.go
+++ b/gateway/connection.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"sync"
 	"time"
@@ -42,6 +43,9 @@ type connection struct {
 	usage                *usageStats
 	permitPortForwarding bool
 	administrator        bool
+
+	// set when this is an inbound connection from a peer node
+	nodeId string
 }
 
 func handleConnection(gateway *gateway, conn *ssh.ServerConn, channels <-chan ssh.NewChannel, requests <-chan *ssh.Request, usage *usageStats) {
@@ -55,11 +59,20 @@ func handleConnection(gateway *gateway, conn *ssh.ServerConn, channels <-chan ss
 		administrator = true
 	}
 
+	// inbound connections from peer nodes carry the node identity
+	nodeId := ""
+	user := conn.User()
+	if _, ok := conn.Permissions.Extensions["peer"]; ok {
+		nodeId = conn.Permissions.Extensions["identity"]
+		user = ""
+	}
+
 	self := &connection{
 		id:                   ksuid.New().String(),
 		gateway:              gateway,
 		conn:                 conn,
-		user:                 conn.User(),
+		user:                 user,
+		nodeId:               nodeId,
 		remoteAddress:        conn.RemoteAddr(),
 		localAddress:         conn.LocalAddr(),
 		services:             make(map[string]map[uint16]bool),
@@ -110,6 +123,9 @@ func handleConnection(gateway *gateway, conn *ssh.ServerConn, channels <-chan ss
 }
 
 func (self *connection) String() string {
+	if self.nodeId != "" {
+		return fmt.Sprintf("connection(id=%q, remote=%q, nodeId=%q)", self.id, self.remoteAddress, self.nodeId)
+	}
 	return fmt.Sprintf("connection(id=%q, remote=%q, user=%q)", self.id, self.remoteAddress, self.user)
 }
 
@@ -428,8 +444,14 @@ func (self *connection) handleTunnelChannel(newChannel ssh.NewChannel) (bool, ss
 		return false, ssh.UnknownChannelType, "failed to decode extra data", err
 	}
 
-	// see if this connection is allowed
-	if !self.permitPortForwarding {
+	// peer nodes may tunnel to the local postgres database
+	if data.Host == "postgres" && data.Port == 5432 {
+		return self.handlePostgresChannel(newChannel)
+	}
+
+	// see if this connection is allowed, peer nodes already checked on the
+	// originating node
+	if !self.permitPortForwarding && self.nodeId == "" {
 		log.Errorf("%s: no permission to port forward", self)
 		return false, ssh.Prohibited, "permission denied", ErrPermissionDenied
 	}
@@ -440,7 +462,15 @@ func (self *connection) handleTunnelChannel(newChannel ssh.NewChannel) (bool, ss
 	}
 	portU16 := uint16(data.Port) // #nosec G115 - safe: checked above for range
 	otherConnection, host, port := self.gateway.lookupConnectionService(data.Host, portU16)
-	if otherConnection == nil {
+
+	// not found locally, see if the target user is connected to another node
+	// in the mesh, requests that arrived from a peer are never forwarded
+	// again to prevent loops
+	var remotePeer *peer
+	if otherConnection == nil && self.nodeId == "" {
+		remotePeer = self.gateway.lookupRemotePeer(context.Background(), data.Host)
+	}
+	if otherConnection == nil && remotePeer == nil {
 		return false, ssh.ConnectionFailed, "service not found or not online", nil
 	}
 
@@ -457,12 +487,20 @@ func (self *connection) handleTunnelChannel(newChannel ssh.NewChannel) (bool, ss
 		defer self.waitGroup.Done()
 
 		// first need to track the opened channel
-		thisTunnel := newTunnel(self, channel, newChannel.ChannelType(), newChannel.ExtraData(), map[string]interface{}{
-			"origin": data.OriginAddress,
-			"to": map[string]interface{}{
+		var toMetadata map[string]interface{}
+		if remotePeer != nil {
+			toMetadata = map[string]interface{}{
+				"nodeId": remotePeer.nodeId,
+			}
+		} else {
+			toMetadata = map[string]interface{}{
 				"user":    otherConnection.user,
 				"address": otherConnection.remoteAddress.String(),
-			},
+			}
+		}
+		thisTunnel := newTunnel(self, channel, newChannel.ChannelType(), newChannel.ExtraData(), map[string]interface{}{
+			"origin": data.OriginAddress,
+			"to":     toMetadata,
 			"service": map[string]interface{}{
 				"host": data.Host,
 				"port": data.Port,
@@ -477,25 +515,45 @@ func (self *connection) handleTunnelChannel(newChannel ssh.NewChannel) (bool, ss
 		defer thisTunnel.close()
 
 		// attempt to open a channel, this can block
-		otherTunnel, err := otherConnection.openTunnel("forwarded-tcpip", marshalTunnelData(&tunnelData{
-			Host:          host,
-			Port:          uint32(port),
-			OriginAddress: data.OriginAddress,
-			OriginPort:    data.OriginPort,
-		}), map[string]interface{}{
-			"origin": data.OriginAddress,
-			"from": map[string]interface{}{
-				"address": self.remoteAddress.String(),
-				"user":    self.user,
-			},
-			"service": map[string]interface{}{
-				"host": data.Host,
-				"port": data.Port,
-			},
-		})
-		if err != nil {
-			log.Warningf("%s: failed to open tunnel to %s: %s", self, otherConnection, err)
-			return
+		var otherTunnel *tunnel
+		if remotePeer != nil {
+			// forward the original request to the node the user is on
+			otherTunnel, err = remotePeer.openTunnel("direct-tcpip", marshalTunnelData(data), map[string]interface{}{
+				"origin": data.OriginAddress,
+				"from": map[string]interface{}{
+					"address": self.remoteAddress.String(),
+					"user":    self.user,
+				},
+				"service": map[string]interface{}{
+					"host": data.Host,
+					"port": data.Port,
+				},
+			})
+			if err != nil {
+				log.Warningf("%s: failed to open tunnel to %s via %s: %s", self, data.Host, remotePeer, err)
+				return
+			}
+		} else {
+			otherTunnel, err = otherConnection.openTunnel("forwarded-tcpip", marshalTunnelData(&tunnelData{
+				Host:          host,
+				Port:          uint32(port),
+				OriginAddress: data.OriginAddress,
+				OriginPort:    data.OriginPort,
+			}), map[string]interface{}{
+				"origin": data.OriginAddress,
+				"from": map[string]interface{}{
+					"address": self.remoteAddress.String(),
+					"user":    self.user,
+				},
+				"service": map[string]interface{}{
+					"host": data.Host,
+					"port": data.Port,
+				},
+			})
+			if err != nil {
+				log.Warningf("%s: failed to open tunnel to %s: %s", self, otherConnection, err)
+				return
+			}
 		}
 		defer otherTunnel.close()
 
@@ -522,4 +580,79 @@ func (self *connection) openTunnel(channelType string, extraData []byte, metadat
 		tunnel.handleRequests(requests)
 	}()
 	return tunnel, nil
+}
+
+// handlePostgresChannel bridges a peer node to the local postgres database,
+// so nodes without direct database access can share the central database
+// through this node's ssh service port.
+func (self *connection) handlePostgresChannel(newChannel ssh.NewChannel) (bool, ssh.RejectionReason, string, error) {
+	// only peer nodes can access postgres
+	if self.nodeId == "" {
+		log.Warningf("%s: non-peer connection attempted to access postgres", self)
+		return false, ssh.Prohibited, "permission denied", ErrPermissionDenied
+	}
+	postgresAddress := self.gateway.settings.PostgresAddress
+	if postgresAddress == "" {
+		log.Warningf("%s: peer requested postgres but no postgres address is configured", self)
+		return false, ssh.Prohibited, "permission denied", ErrPermissionDenied
+	}
+
+	log.Infof("%s: peer node opening postgres tunnel to %s", self, postgresAddress)
+
+	channel, requests, err := newChannel.Accept()
+	if err != nil {
+		log.Errorf("%s: failed to accept postgres channel: %s", self, err)
+		return true, 0, "", err
+	}
+
+	self.waitGroup.Add(1)
+	go func() {
+		defer deferutil.Recover()
+		defer self.waitGroup.Done()
+		ssh.DiscardRequests(requests)
+	}()
+
+	self.waitGroup.Add(1)
+	go func() {
+		defer deferutil.Recover()
+		defer self.waitGroup.Done()
+
+		defer func() {
+			if err := channel.Close(); err != nil {
+				log.Warningf("%s: failed to close postgres channel: %s", self, err)
+			}
+		}()
+
+		conn, err := net.DialTimeout("tcp", postgresAddress, 10*time.Second)
+		if err != nil {
+			log.Errorf("%s: failed to connect to postgres at %s: %s", self, postgresAddress, err)
+			return
+		}
+		defer func() {
+			if err := conn.Close(); err != nil {
+				log.Warningf("%s: failed to close postgres connection: %s", self, err)
+			}
+		}()
+
+		done1 := make(chan struct{})
+		go func() {
+			defer deferutil.Recover()
+			defer close(done1)
+			_, _ = io.Copy(channel, conn)
+		}()
+
+		done2 := make(chan struct{})
+		go func() {
+			defer deferutil.Recover()
+			defer close(done2)
+			_, _ = io.Copy(conn, channel)
+		}()
+
+		select {
+		case <-done1:
+		case <-done2:
+		}
+	}()
+
+	return true, 0, "", nil
 }

--- a/gateway/connection.go
+++ b/gateway/connection.go
@@ -381,6 +381,11 @@ func (self *connection) handleChannel(newChannel ssh.NewChannel) error {
 
 	switch newChannel.ChannelType() {
 	case "session":
+		// peer connections have no user and must not reach the session
+		// handlers, which would otherwise write an empty-named user row
+		if self.nodeId != "" {
+			return newChannel.Reject(ssh.Prohibited, "sessions not allowed on peer connections")
+		}
 		ok, rejection, message, err = self.handleSessionChannel(newChannel)
 	case "direct-tcpip":
 		ok, rejection, message, err = self.handleTunnelChannel(newChannel)
@@ -468,7 +473,9 @@ func (self *connection) handleTunnelChannel(newChannel ssh.NewChannel) (bool, ss
 	// again to prevent loops
 	var remotePeer *peer
 	if otherConnection == nil && self.nodeId == "" {
-		remotePeer = self.gateway.lookupRemotePeer(context.Background(), data.Host)
+		lookupContext, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		remotePeer = self.gateway.lookupRemotePeer(lookupContext, data.Host)
+		cancel()
 	}
 	if otherConnection == nil && remotePeer == nil {
 		return false, ssh.ConnectionFailed, "service not found or not online", nil
@@ -486,18 +493,35 @@ func (self *connection) handleTunnelChannel(newChannel ssh.NewChannel) (bool, ss
 		defer deferutil.Recover()
 		defer self.waitGroup.Done()
 
-		// first need to track the opened channel
+		// pick the target: a remote peer (forward the original request to the
+		// node the user is on) or a local connection (resolved host/port)
+		var target tunnelOpener
+		var targetChannelType string
+		var targetData []byte
 		var toMetadata map[string]interface{}
 		if remotePeer != nil {
+			target = remotePeer
+			targetChannelType = "direct-tcpip"
+			targetData = marshalTunnelData(data)
 			toMetadata = map[string]interface{}{
 				"nodeId": remotePeer.nodeId,
 			}
 		} else {
+			target = otherConnection
+			targetChannelType = "forwarded-tcpip"
+			targetData = marshalTunnelData(&tunnelData{
+				Host:          host,
+				Port:          uint32(port),
+				OriginAddress: data.OriginAddress,
+				OriginPort:    data.OriginPort,
+			})
 			toMetadata = map[string]interface{}{
 				"user":    otherConnection.user,
 				"address": otherConnection.remoteAddress.String(),
 			}
 		}
+
+		// first need to track the opened channel
 		thisTunnel := newTunnel(self, channel, newChannel.ChannelType(), newChannel.ExtraData(), map[string]interface{}{
 			"origin": data.OriginAddress,
 			"to":     toMetadata,
@@ -515,45 +539,20 @@ func (self *connection) handleTunnelChannel(newChannel ssh.NewChannel) (bool, ss
 		defer thisTunnel.close()
 
 		// attempt to open a channel, this can block
-		var otherTunnel *tunnel
-		if remotePeer != nil {
-			// forward the original request to the node the user is on
-			otherTunnel, err = remotePeer.openTunnel("direct-tcpip", marshalTunnelData(data), map[string]interface{}{
-				"origin": data.OriginAddress,
-				"from": map[string]interface{}{
-					"address": self.remoteAddress.String(),
-					"user":    self.user,
-				},
-				"service": map[string]interface{}{
-					"host": data.Host,
-					"port": data.Port,
-				},
-			})
-			if err != nil {
-				log.Warningf("%s: failed to open tunnel to %s via %s: %s", self, data.Host, remotePeer, err)
-				return
-			}
-		} else {
-			otherTunnel, err = otherConnection.openTunnel("forwarded-tcpip", marshalTunnelData(&tunnelData{
-				Host:          host,
-				Port:          uint32(port),
-				OriginAddress: data.OriginAddress,
-				OriginPort:    data.OriginPort,
-			}), map[string]interface{}{
-				"origin": data.OriginAddress,
-				"from": map[string]interface{}{
-					"address": self.remoteAddress.String(),
-					"user":    self.user,
-				},
-				"service": map[string]interface{}{
-					"host": data.Host,
-					"port": data.Port,
-				},
-			})
-			if err != nil {
-				log.Warningf("%s: failed to open tunnel to %s: %s", self, otherConnection, err)
-				return
-			}
+		otherTunnel, err := target.openTunnel(targetChannelType, targetData, map[string]interface{}{
+			"origin": data.OriginAddress,
+			"from": map[string]interface{}{
+				"address": self.remoteAddress.String(),
+				"user":    self.user,
+			},
+			"service": map[string]interface{}{
+				"host": data.Host,
+				"port": data.Port,
+			},
+		})
+		if err != nil {
+			log.Warningf("%s: failed to open tunnel to %s via %s: %s", self, data.Host, target, err)
+			return
 		}
 		defer otherTunnel.close()
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"net"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -49,6 +50,8 @@ type Gateway interface {
 	Close()
 
 	HandleConnection(net.Conn)
+	HandleSocksConnection(net.Conn)
+	HTTPProxyHandler() http.Handler
 	ScavengeConnections(time.Duration)
 
 	ListUsers(context.Context) (interface{}, error)
@@ -235,6 +238,40 @@ func (self *gateway) lookupRemotePeer(ctx context.Context, host string) *peer {
 		log.Debugf("lookup: user %q is on node %s but no peer connection is available", user, model.NodeID)
 	}
 	return nil
+}
+
+// openServiceTunnel opens a tunnel to the exposed service host:port on behalf
+// of an external proxy client (socks/http). It mirrors the routing in
+// connection.handleTunnelChannel: a locally-connected service first, otherwise
+// a service on a peer node. originAddress/originPort describe the proxy client.
+func (self *gateway) openServiceTunnel(host string, port uint16, originAddress string, originPort uint32) (*tunnel, error) {
+	metadata := map[string]interface{}{
+		"origin": originAddress,
+		"service": map[string]interface{}{
+			"host": host,
+			"port": port,
+		},
+	}
+	if otherConnection, serviceHost, servicePort := self.lookupConnectionService(host, port); otherConnection != nil {
+		return otherConnection.openTunnel("forwarded-tcpip", marshalTunnelData(&tunnelData{
+			Host:          serviceHost,
+			Port:          uint32(servicePort),
+			OriginAddress: originAddress,
+			OriginPort:    originPort,
+		}), metadata)
+	}
+	lookupContext, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	remotePeer := self.lookupRemotePeer(lookupContext, host)
+	cancel()
+	if remotePeer != nil {
+		return remotePeer.openTunnel("direct-tcpip", marshalTunnelData(&tunnelData{
+			Host:          host,
+			Port:          uint32(port),
+			OriginAddress: originAddress,
+			OriginPort:    originPort,
+		}), metadata)
+	}
+	return nil, ErrServiceNotFound
 }
 
 // returns a list of connections

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -86,7 +86,7 @@ func Open(database db.Database, sshConfig *ssh.ServerConfig, settings *Settings)
 		done:             make(chan struct{}),
 	}
 	if settings.NodeID != "" {
-		if err := self.registerNode(context.Background(), true); err != nil {
+		if err := self.registerNode(context.Background(), true, true); err != nil {
 			return nil, err
 		}
 		self.waitGroup.Add(1)
@@ -116,7 +116,7 @@ func (self *gateway) Close() {
 	self.waitGroup.Wait()
 
 	// mark this node as offline in the database
-	if err := self.registerNode(context.Background(), false); err != nil {
+	if err := self.registerNode(context.Background(), false, false); err != nil {
 		log.Warningf("failed to mark node as offline: %s", err)
 	}
 }
@@ -220,8 +220,10 @@ func (self *gateway) lookupRemotePeer(ctx context.Context, host string) *peer {
 		}
 		model, err := self.database.GetUser(ctx, user)
 		if err != nil {
+			// a transient error on one candidate must not abort resolving the
+			// remaining, more-specific user suffixes
 			log.Warningf("failed to look up user %q for mesh tunneling: %s", user, err)
-			return nil
+			continue
 		}
 		if model == nil || model.NodeID == "" || model.NodeID == self.settings.NodeID {
 			continue

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -11,12 +11,37 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/ziyan/gatewaysshd/db"
+	"github.com/ziyan/gatewaysshd/util/deferutil"
 )
 
 var log = logging.MustGetLogger("gateway")
 
 type Settings struct {
+	// version string
 	Version string
+
+	// id of this node, empty disables node registration and mesh tunneling
+	NodeID string
+
+	// address where peer nodes can reach this node, empty means other nodes
+	// cannot dial this node
+	NodeAddress string
+
+	// host public key of this node, published to the node table so dialing
+	// peers can pin it
+	HostPublicKey ssh.PublicKey
+
+	// certificate signer used to authenticate to other nodes, a user
+	// certificate signed by the peer certificate authority with the "peer"
+	// principal and the node id as key id, nil disables outbound peering
+	NodeSigner ssh.Signer
+
+	// address of the local postgres database bridged for peer nodes, empty
+	// refuses postgres tunnels
+	PostgresAddress string
+
+	// how often to look for new peer nodes, defaults to 15 seconds
+	PeerDiscoveryInterval time.Duration
 }
 
 // an instance of gateway, contains runtime states
@@ -38,23 +63,61 @@ type gateway struct {
 	connectionsIndex map[string][]*connection
 	connectionsList  []*connection
 	lock             sync.Mutex
+
+	// map from peer node id to outbound peer, protected by peersLock
+	peers     map[string]*peer
+	peersLock sync.Mutex
+
+	// lifetime management for background loops
+	done      chan struct{}
+	closeOnce sync.Once
+	waitGroup sync.WaitGroup
 }
 
 // creates a new instance of gateway
 func Open(database db.Database, sshConfig *ssh.ServerConfig, settings *Settings) (Gateway, error) {
-	return &gateway{
+	self := &gateway{
 		database:         database,
 		sshConfig:        sshConfig,
 		settings:         settings,
 		connectionsIndex: make(map[string][]*connection),
 		connectionsList:  make([]*connection, 0),
-	}, nil
+		peers:            make(map[string]*peer),
+		done:             make(chan struct{}),
+	}
+	if settings.NodeID != "" {
+		if err := self.registerNode(context.Background(), true); err != nil {
+			return nil, err
+		}
+		self.waitGroup.Add(1)
+		go func() {
+			defer deferutil.Recover()
+			defer self.waitGroup.Done()
+			self.runPeers(context.Background())
+		}()
+	}
+	return self, nil
 }
 
 // close the gateway instance
 func (self *gateway) Close() {
+	self.closeOnce.Do(func() {
+		close(self.done)
+	})
+
 	for _, connection := range self.listConnections() {
 		connection.close()
+	}
+
+	for _, peer := range self.listPeers() {
+		peer.close()
+	}
+
+	self.waitGroup.Wait()
+
+	// mark this node as offline in the database
+	if err := self.registerNode(context.Background(), false); err != nil {
+		log.Warningf("failed to mark node as offline: %s", err)
 	}
 }
 
@@ -140,6 +203,36 @@ func (self *gateway) lookupConnectionService(host string, port uint16) (*connect
 
 	log.Debugf("lookup: failed to find service: host = %s, port = %d", host, port)
 	return nil, "", 0
+}
+
+// lookupRemotePeer finds the peer of the node the target user last connected
+// to, so the tunnel can be forwarded across the mesh. The host is split the
+// same way as lookupConnectionService to find the user name candidates.
+func (self *gateway) lookupRemotePeer(ctx context.Context, host string) *peer {
+	if self.settings.NodeID == "" {
+		return nil // mesh disabled
+	}
+	parts := strings.Split(host, ".")
+	for index := range parts {
+		user := strings.Join(parts[index:], ".")
+		if user == "" {
+			continue
+		}
+		model, err := self.database.GetUser(ctx, user)
+		if err != nil {
+			log.Warningf("failed to look up user %q for mesh tunneling: %s", user, err)
+			return nil
+		}
+		if model == nil || model.NodeID == "" || model.NodeID == self.settings.NodeID {
+			continue
+		}
+		if peer := self.getPeer(model.NodeID); peer != nil {
+			log.Debugf("lookup: found remote node for host %q: node = %s", host, model.NodeID)
+			return peer
+		}
+		log.Debugf("lookup: user %q is on node %s but no peer connection is available", user, model.NodeID)
+	}
+	return nil
 }
 
 // returns a list of connections

--- a/gateway/gateway_integration_test.go
+++ b/gateway/gateway_integration_test.go
@@ -68,7 +68,7 @@ func startTestGateway(t *testing.T) (string, ssh.Signer, gateway.Gateway, db.Dat
 
 	caSigner := newTestSigner(t)
 	sshConfig, err := auth.NewConfig(database, &auth.Settings{
-		CaPublicKeys:  []ssh.PublicKey{caSigner.PublicKey()},
+		CAPublicKeys:  []ssh.PublicKey{caSigner.PublicKey()},
 		GeoipDatabase: "missing-geoip.mmdb",
 	})
 	if err != nil {

--- a/gateway/gateway_integration_test.go
+++ b/gateway/gateway_integration_test.go
@@ -67,7 +67,10 @@ func startTestGateway(t *testing.T) (string, ssh.Signer, gateway.Gateway, db.Dat
 	database, releaseDatabase := dbtest.AcquireDatabase(t)
 
 	caSigner := newTestSigner(t)
-	sshConfig, err := auth.NewConfig(database, []ssh.PublicKey{caSigner.PublicKey()}, "missing-geoip.mmdb")
+	sshConfig, err := auth.NewConfig(database, &auth.Settings{
+		CaPublicKeys:  []ssh.PublicKey{caSigner.PublicKey()},
+		GeoipDatabase: "missing-geoip.mmdb",
+	})
 	if err != nil {
 		t.Fatalf("failed to create ssh config: %s", err)
 	}

--- a/gateway/httpproxy.go
+++ b/gateway/httpproxy.go
@@ -1,0 +1,143 @@
+package gateway
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// HTTPProxyHandler returns a forward-proxy handler: the CONNECT method tunnels
+// arbitrary tcp (like "ssh -D"), and absolute-form requests are forwarded as a
+// plain http proxy. Like the socks proxy it is unauthenticated and reaches any
+// exposed service, so it should only be bound to a trusted network.
+func (self *gateway) HTTPProxyHandler() http.Handler {
+	reverseProxy := &httputil.ReverseProxy{
+		// the request already carries an absolute target url in forward-proxy
+		// form, so no rewriting is needed
+		Director: func(request *http.Request) {},
+		Transport: &http.Transport{
+			DialContext:         self.dialServiceContext,
+			MaxIdleConns:        100,
+			MaxIdleConnsPerHost: 10,
+			IdleConnTimeout:     90 * time.Second,
+		},
+	}
+
+	return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.Method == http.MethodConnect {
+			self.handleHttpConnect(response, request)
+			return
+		}
+		if !request.URL.IsAbs() {
+			http.Error(response, "gatewaysshd: proxy requires an absolute request uri", http.StatusBadRequest)
+			return
+		}
+		reverseProxy.ServeHTTP(response, request)
+	})
+}
+
+// handleHttpConnect tunnels a CONNECT request to the requested service.
+func (self *gateway) handleHttpConnect(response http.ResponseWriter, request *http.Request) {
+	host, port, err := splitHostPort(request.Host, 443)
+	if err != nil {
+		http.Error(response, "gatewaysshd: invalid connect target", http.StatusBadRequest)
+		return
+	}
+
+	originAddress, originPort := splitOrigin(remoteAddress(request))
+	tunnel, err := self.openServiceTunnel(host, port, originAddress, originPort)
+	if err != nil {
+		log.Warningf("http connect: failed to open tunnel to %s:%d: %s", host, port, err)
+		http.Error(response, "gatewaysshd: host unreachable", http.StatusBadGateway)
+		return
+	}
+	defer tunnel.close()
+
+	hijacker, ok := response.(http.Hijacker)
+	if !ok {
+		http.Error(response, "gatewaysshd: connect not supported", http.StatusInternalServerError)
+		return
+	}
+	clientConn, _, err := hijacker.Hijack()
+	if err != nil {
+		log.Warningf("http connect: failed to hijack connection: %s", err)
+		return
+	}
+	defer func() {
+		_ = clientConn.Close()
+	}()
+
+	if _, err := clientConn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); err != nil {
+		return
+	}
+
+	bridge(clientConn, tunnel.channel)
+}
+
+// dialServiceContext resolves an absolute-form http proxy request to a tunnel,
+// used by the reverse proxy transport for plain (non-CONNECT) http.
+func (self *gateway) dialServiceContext(ctx context.Context, network, address string) (net.Conn, error) {
+	host, port, err := splitHostPort(address, 80)
+	if err != nil {
+		return nil, err
+	}
+	tunnel, err := self.openServiceTunnel(host, port, "http-proxy", 0)
+	if err != nil {
+		return nil, err
+	}
+	return &channelConn{channel: tunnel.channel, tunnel: tunnel}, nil
+}
+
+func remoteAddress(request *http.Request) net.Addr {
+	if host, portString, err := net.SplitHostPort(request.RemoteAddr); err == nil {
+		if port, err := strconv.Atoi(portString); err == nil {
+			return &net.TCPAddr{IP: net.ParseIP(host), Port: port}
+		}
+	}
+	return &net.TCPAddr{}
+}
+
+// splitHostPort splits host:port, defaulting the port when absent.
+func splitHostPort(hostPort string, defaultPort uint16) (string, uint16, error) {
+	host, portString, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		if strings.Contains(err.Error(), "missing port") {
+			return hostPort, defaultPort, nil
+		}
+		return "", 0, err
+	}
+	port, err := strconv.ParseUint(portString, 10, 16)
+	if err != nil {
+		return "", 0, err
+	}
+	return host, uint16(port), nil
+}
+
+// channelConn adapts an ssh channel to net.Conn for the reverse proxy
+// transport. Deadlines are unsupported by ssh channels and are no-ops.
+type channelConn struct {
+	channel ssh.Channel
+	tunnel  *tunnel
+}
+
+func (self *channelConn) Read(data []byte) (int, error)  { return self.channel.Read(data) }
+func (self *channelConn) Write(data []byte) (int, error) { return self.channel.Write(data) }
+
+func (self *channelConn) Close() error {
+	self.tunnel.close()
+	return nil
+}
+
+func (self *channelConn) LocalAddr() net.Addr                      { return &net.TCPAddr{} }
+func (self *channelConn) RemoteAddr() net.Addr                     { return &net.TCPAddr{} }
+func (self *channelConn) SetDeadline(deadline time.Time) error     { return nil }
+func (self *channelConn) SetReadDeadline(deadline time.Time) error { return nil }
+func (self *channelConn) SetWriteDeadline(deadline time.Time) error {
+	return nil
+}

--- a/gateway/mesh_integration_test.go
+++ b/gateway/mesh_integration_test.go
@@ -47,8 +47,8 @@ func startTestNode(t *testing.T, database db.Database, userCaSigner, peerCaSigne
 
 	hostSigner := newTestSigner(t)
 	sshConfig, err := auth.NewConfig(database, &auth.Settings{
-		CaPublicKeys:     []ssh.PublicKey{userCaSigner.PublicKey()},
-		PeerCaPublicKeys: []ssh.PublicKey{peerCaSigner.PublicKey()},
+		CAPublicKeys:     []ssh.PublicKey{userCaSigner.PublicKey()},
+		PeerCAPublicKeys: []ssh.PublicKey{peerCaSigner.PublicKey()},
 		NodeID:           nodeId,
 		GeoipDatabase:    "missing-geoip.mmdb",
 	})
@@ -211,8 +211,8 @@ func TestGatewayPostgresViaPeer(t *testing.T) {
 
 	hostSigner := newTestSigner(t)
 	sshConfig, err := auth.NewConfig(database, &auth.Settings{
-		CaPublicKeys:     []ssh.PublicKey{userCaSigner.PublicKey()},
-		PeerCaPublicKeys: []ssh.PublicKey{peerCaSigner.PublicKey()},
+		CAPublicKeys:     []ssh.PublicKey{userCaSigner.PublicKey()},
+		PeerCAPublicKeys: []ssh.PublicKey{peerCaSigner.PublicKey()},
 		NodeID:           "node-central",
 		GeoipDatabase:    "missing-geoip.mmdb",
 	})
@@ -343,8 +343,18 @@ func TestGatewayPostgresRequiresPeer(t *testing.T) {
 		_ = client.Close()
 	}()
 
-	if _, err := client.Dial("tcp", "postgres:5432"); err == nil {
-		t.Fatal("expected postgres tunnel to be rejected for regular users")
+	// a regular user gets no postgres bridge: "postgres:5432" is just an
+	// ordinary (unregistered) service, so the tunnel is accepted then closed
+	// rather than bridged to the database
+	tunnel, err := client.Dial("tcp", "postgres:5432")
+	if err != nil {
+		return // rejected outright is also acceptable
+	}
+	defer func() {
+		_ = tunnel.Close()
+	}()
+	if _, err := tunnel.Read(make([]byte, 1)); err == nil {
+		t.Fatal("regular user reached the postgres bridge")
 	}
 }
 
@@ -443,5 +453,52 @@ func TestGatewayPeerExtensionNotForgeable(t *testing.T) {
 	}
 	if _, err := client.Dial("tcp", "anything.someone:22"); err == nil {
 		t.Fatal("forged peer extension bypassed port-forward permission")
+	}
+}
+
+// TestGatewayPeerSessionRejected proves a peer connection cannot open a session
+// channel (which would drive PutUser with an empty username).
+func TestGatewayPeerSessionRejected(t *testing.T) {
+	t.Parallel()
+	database, release := dbtest.AcquireDatabase(t)
+	defer release()
+
+	peerCaSigner := newTestSigner(t)
+	userCaSigner := newTestSigner(t)
+	address, _, releaseNode := startTestNode(t, database, userCaSigner, peerCaSigner, "node-a", "")
+	defer releaseNode()
+
+	// dial as a genuine peer node
+	client, err := ssh.Dial("tcp", address, &ssh.ClientConfig{
+		User:            auth.PeerUser,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(newNodeCertSigner(t, peerCaSigner, "node-b"))},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
+		Timeout:         10 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("failed to dial as peer: %s", err)
+	}
+	defer func() {
+		_ = client.Close()
+	}()
+
+	// the session channel is rejected via accept-then-close, so NewSession may
+	// succeed client-side but running a command (which would reach the session
+	// handlers) must fail and must not create an empty-named user
+	session, err := client.NewSession()
+	if err == nil {
+		// a bare JSON command takes the legacy status path -> reportStatus ->
+		// PutUser(self.user); for a peer self.user is "", so without the
+		// session gate this would create an empty-named user
+		_ = session.Run("{}")
+		_ = session.Close()
+	}
+
+	user, err := database.GetUser(t.Context(), "")
+	if err != nil {
+		t.Fatalf("failed to query empty user: %s", err)
+	}
+	if user != nil {
+		t.Fatalf("peer session created an empty-named user: %+v", user)
 	}
 }

--- a/gateway/mesh_integration_test.go
+++ b/gateway/mesh_integration_test.go
@@ -410,3 +410,38 @@ func TestGatewayNodeRegistration(t *testing.T) {
 		t.Fatalf("expected node to be offline after close, got %+v", node)
 	}
 }
+
+// TestGatewayPeerExtensionNotForgeable proves a regular user certificate that
+// carries a "peer"/"identity" extension is NOT treated as a peer node: the
+// user certificate authority must not be able to grant node capabilities.
+func TestGatewayPeerExtensionNotForgeable(t *testing.T) {
+	t.Parallel()
+	database, release := dbtest.AcquireDatabase(t)
+	defer release()
+
+	peerCaSigner := newTestSigner(t)
+	userCaSigner := newTestSigner(t)
+	// this node has a real postgres address, so a genuine peer could bridge it
+	address, _, releaseNode := startTestNode(t, database, userCaSigner, peerCaSigner, "node-a", "127.0.0.1:5432")
+	defer releaseNode()
+
+	// a user certificate (signed by the user CA) forging the peer markers, and
+	// deliberately without permit-port-forwarding
+	forged := newCertSigner(t, userCaSigner, "mallory", map[string]string{
+		"peer":     "",
+		"identity": "node-evil",
+	})
+	client := dialTestGateway(t, address, forged, "mallory")
+	defer func() {
+		_ = client.Close()
+	}()
+
+	// if the forged extension had been honored, nodeId != "" would bypass the
+	// port-forward check and unlock the postgres bridge; both must be denied
+	if _, err := client.Dial("tcp", "postgres:5432"); err == nil {
+		t.Fatal("forged peer extension granted postgres access")
+	}
+	if _, err := client.Dial("tcp", "anything.someone:22"); err == nil {
+		t.Fatal("forged peer extension bypassed port-forward permission")
+	}
+}

--- a/gateway/mesh_integration_test.go
+++ b/gateway/mesh_integration_test.go
@@ -1,0 +1,412 @@
+package gateway_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/ziyan/gatewaysshd/auth"
+	"github.com/ziyan/gatewaysshd/db"
+	"github.com/ziyan/gatewaysshd/db/dbtest"
+	"github.com/ziyan/gatewaysshd/gateway"
+	"github.com/ziyan/gatewaysshd/util/deferutil"
+)
+
+// newNodeCertSigner returns a signer for a node certificate: signed by the
+// peer certificate authority, "peer" principal, node id as key id.
+func newNodeCertSigner(t *testing.T, peerCaSigner ssh.Signer, nodeId string) ssh.Signer {
+	t.Helper()
+	nodeSigner := newTestSigner(t)
+	certificate := &ssh.Certificate{
+		Key:             nodeSigner.PublicKey(),
+		CertType:        ssh.UserCert,
+		KeyId:           nodeId,
+		ValidPrincipals: []string{auth.PeerUser},
+		ValidAfter:      0,
+		ValidBefore:     ssh.CertTimeInfinity,
+	}
+	if err := certificate.SignCert(rand.Reader, peerCaSigner); err != nil {
+		t.Fatalf("failed to sign node certificate: %s", err)
+	}
+	certSigner, err := ssh.NewCertSigner(certificate, nodeSigner)
+	if err != nil {
+		t.Fatalf("failed to create node cert signer: %s", err)
+	}
+	return certSigner
+}
+
+// startTestNode starts a gateway participating in the mesh, with its own user
+// certificate authority and host key, sharing the given database.
+func startTestNode(t *testing.T, database db.Database, userCaSigner, peerCaSigner ssh.Signer, nodeId, postgresAddress string) (string, gateway.Gateway, func()) {
+	t.Helper()
+
+	hostSigner := newTestSigner(t)
+	sshConfig, err := auth.NewConfig(database, &auth.Settings{
+		CaPublicKeys:     []ssh.PublicKey{userCaSigner.PublicKey()},
+		PeerCaPublicKeys: []ssh.PublicKey{peerCaSigner.PublicKey()},
+		NodeID:           nodeId,
+		GeoipDatabase:    "missing-geoip.mmdb",
+	})
+	if err != nil {
+		t.Fatalf("failed to create ssh config: %s", err)
+	}
+	sshConfig.AddHostKey(hostSigner)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %s", err)
+	}
+	address := listener.Addr().String()
+
+	instance, err := gateway.Open(database, sshConfig, &gateway.Settings{
+		Version:               "test",
+		NodeID:                nodeId,
+		NodeAddress:           address,
+		HostPublicKey:         hostSigner.PublicKey(),
+		NodeSigner:            newNodeCertSigner(t, peerCaSigner, nodeId),
+		PostgresAddress:       postgresAddress,
+		PeerDiscoveryInterval: 200 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("failed to open gateway node %s: %s", nodeId, err)
+	}
+
+	go func() {
+		defer deferutil.Recover()
+		for {
+			socket, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer deferutil.Recover()
+				instance.HandleConnection(socket)
+			}()
+		}
+	}()
+
+	return address, instance, func() {
+		if err := listener.Close(); err != nil {
+			t.Fatalf("failed to close listener: %s", err)
+		}
+		instance.Close()
+	}
+}
+
+// TestGatewayMeshTunnel proves a user on one node can reach a service exposed
+// by a user on another node, with each node trusting a different user
+// certificate authority and sharing only the database and the peer
+// certificate authority.
+func TestGatewayMeshTunnel(t *testing.T) {
+	t.Parallel()
+	database, release := dbtest.AcquireDatabase(t)
+	defer release()
+
+	peerCaSigner := newTestSigner(t)
+	userCaSignerA := newTestSigner(t)
+	userCaSignerB := newTestSigner(t)
+
+	addressA, _, releaseA := startTestNode(t, database, userCaSignerA, peerCaSigner, "node-a", "")
+	defer releaseA()
+	addressB, _, releaseB := startTestNode(t, database, userCaSignerB, peerCaSigner, "node-b", "")
+	defer releaseB()
+
+	extensions := map[string]string{"permit-port-forwarding": ""}
+
+	// alice connects to node b with a certificate from node b's user ca and
+	// advertises an echo service
+	alice := dialTestGateway(t, addressB, newCertSigner(t, userCaSignerB, "alice", extensions), "alice")
+	defer func() {
+		_ = alice.Close()
+	}()
+
+	forwarded := alice.HandleChannelOpen("forwarded-tcpip")
+	go func() {
+		defer deferutil.Recover()
+		for newChannel := range forwarded {
+			channel, requests, err := newChannel.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer deferutil.Recover()
+				ssh.DiscardRequests(requests)
+			}()
+			go func() {
+				defer deferutil.Recover()
+				defer func() {
+					_ = channel.Close()
+				}()
+				_, _ = io.Copy(channel, channel)
+			}()
+		}
+	}()
+
+	forwardPayload := ssh.Marshal(&struct {
+		Host string
+		Port uint32
+	}{Host: "myservice", Port: 8000})
+	ok, _, err := alice.SendRequest("tcpip-forward", true, forwardPayload)
+	if err != nil || !ok {
+		t.Fatalf("tcpip-forward failed: ok = %v, err = %v", ok, err)
+	}
+
+	// bob connects to node a with a certificate from node a's user ca
+	bob := dialTestGateway(t, addressA, newCertSigner(t, userCaSignerA, "bob", extensions), "bob")
+	defer func() {
+		_ = bob.Close()
+	}()
+
+	// node a needs its outbound peer connection to node b before it can
+	// forward, and a rejected tunnel still dials successfully and surfaces
+	// as EOF on first use, so retry the whole echo round trip until
+	// discovery has caught up
+	message := []byte("hello across the mesh")
+	echo := make([]byte, len(message))
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		echoErr := func() error {
+			tunnel, err := bob.Dial("tcp", "myservice.alice:8000")
+			if err != nil {
+				return err
+			}
+			defer func() {
+				_ = tunnel.Close()
+			}()
+			if _, err := tunnel.Write(message); err != nil {
+				return err
+			}
+			if _, err := io.ReadFull(tunnel, echo); err != nil {
+				return err
+			}
+			return nil
+		}()
+		if echoErr == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("failed to echo through mesh tunnel: %s", echoErr)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if !bytes.Equal(echo, message) {
+		t.Fatalf("expected %q, got %q", message, echo)
+	}
+}
+
+// TestGatewayPostgresViaPeer proves a node without direct database access can
+// reach the central postgres through a peer node's ssh service port.
+func TestGatewayPostgresViaPeer(t *testing.T) {
+	t.Parallel()
+	database, settings, release := dbtest.AcquireDatabaseWithSettings(t)
+	defer release()
+
+	peerCaSigner := newTestSigner(t)
+	userCaSigner := newTestSigner(t)
+
+	hostSigner := newTestSigner(t)
+	sshConfig, err := auth.NewConfig(database, &auth.Settings{
+		CaPublicKeys:     []ssh.PublicKey{userCaSigner.PublicKey()},
+		PeerCaPublicKeys: []ssh.PublicKey{peerCaSigner.PublicKey()},
+		NodeID:           "node-central",
+		GeoipDatabase:    "missing-geoip.mmdb",
+	})
+	if err != nil {
+		t.Fatalf("failed to create ssh config: %s", err)
+	}
+	sshConfig.AddHostKey(hostSigner)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %s", err)
+	}
+	defer func() {
+		_ = listener.Close()
+	}()
+
+	instance, err := gateway.Open(database, sshConfig, &gateway.Settings{
+		Version:         "test",
+		NodeID:          "node-central",
+		NodeAddress:     listener.Addr().String(),
+		HostPublicKey:   hostSigner.PublicKey(),
+		PostgresAddress: net.JoinHostPort(settings.Host, "5432"),
+	})
+	if err != nil {
+		t.Fatalf("failed to open gateway: %s", err)
+	}
+	defer instance.Close()
+
+	go func() {
+		defer deferutil.Recover()
+		for {
+			socket, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer deferutil.Recover()
+				instance.HandleConnection(socket)
+			}()
+		}
+	}()
+
+	// open the same database through the peer tunnel
+	tunneled, err := db.Open(&db.Settings{
+		Host:              "postgres",
+		Port:              5432,
+		User:              settings.User,
+		Password:          settings.Password,
+		DatabaseName:      settings.DatabaseName,
+		PeerAddress:       listener.Addr().String(),
+		PeerSigner:        newNodeCertSigner(t, peerCaSigner, "node-remote"),
+		PeerHostPublicKey: hostSigner.PublicKey(),
+	})
+	if err != nil {
+		t.Fatalf("failed to open database via peer: %s", err)
+	}
+	defer func() {
+		_ = tunneled.Close()
+	}()
+
+	if _, err := tunneled.PutUser(t.Context(), "carol", func(user *db.User) error {
+		user.Comment = "created through the peer tunnel"
+		return nil
+	}); err != nil {
+		t.Fatalf("failed to put user via peer tunnel: %s", err)
+	}
+
+	// visible through the direct connection
+	user, err := database.GetUser(t.Context(), "carol")
+	if err != nil {
+		t.Fatalf("failed to get user: %s", err)
+	}
+	if user == nil || user.Comment != "created through the peer tunnel" {
+		t.Fatalf("unexpected user: %+v", user)
+	}
+}
+
+// TestGatewayPeerAuthUsesSeparateCa proves the user certificate authority
+// cannot authenticate peers and the peer certificate authority cannot
+// authenticate users.
+func TestGatewayPeerAuthUsesSeparateCa(t *testing.T) {
+	t.Parallel()
+	database, release := dbtest.AcquireDatabase(t)
+	defer release()
+
+	peerCaSigner := newTestSigner(t)
+	userCaSigner := newTestSigner(t)
+
+	address, _, releaseNode := startTestNode(t, database, userCaSigner, peerCaSigner, "node-a", "")
+	defer releaseNode()
+
+	// a peer certificate signed by the user ca must be rejected
+	if _, err := ssh.Dial("tcp", address, &ssh.ClientConfig{
+		User:            auth.PeerUser,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(newNodeCertSigner(t, userCaSigner, "node-x"))},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
+		Timeout:         10 * time.Second,
+	}); err == nil {
+		t.Fatal("expected peer authentication with user ca to fail")
+	}
+
+	// a user certificate signed by the peer ca must be rejected
+	if _, err := ssh.Dial("tcp", address, &ssh.ClientConfig{
+		User:            "mallory",
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(newCertSigner(t, peerCaSigner, "mallory", nil))},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
+		Timeout:         10 * time.Second,
+	}); err == nil {
+		t.Fatal("expected user authentication with peer ca to fail")
+	}
+}
+
+// TestGatewayPostgresRequiresPeer proves regular users cannot reach the
+// postgres bridge even with port forwarding permission.
+func TestGatewayPostgresRequiresPeer(t *testing.T) {
+	t.Parallel()
+	database, release := dbtest.AcquireDatabase(t)
+	defer release()
+
+	peerCaSigner := newTestSigner(t)
+	userCaSigner := newTestSigner(t)
+	address, _, releaseNode := startTestNode(t, database, userCaSigner, peerCaSigner, "node-a", "127.0.0.1:5432")
+	defer releaseNode()
+
+	extensions := map[string]string{"permit-port-forwarding": ""}
+	client := dialTestGateway(t, address, newCertSigner(t, userCaSigner, "alice", extensions), "alice")
+	defer func() {
+		_ = client.Close()
+	}()
+
+	if _, err := client.Dial("tcp", "postgres:5432"); err == nil {
+		t.Fatal("expected postgres tunnel to be rejected for regular users")
+	}
+}
+
+// TestGatewayMeshUnknownUserFails proves tunnels to users unknown to the mesh
+// are cleanly rejected.
+func TestGatewayMeshUnknownUserFails(t *testing.T) {
+	t.Parallel()
+	database, release := dbtest.AcquireDatabase(t)
+	defer release()
+
+	peerCaSigner := newTestSigner(t)
+	userCaSigner := newTestSigner(t)
+	address, _, releaseNode := startTestNode(t, database, userCaSigner, peerCaSigner, "node-a", "")
+	defer releaseNode()
+
+	extensions := map[string]string{"permit-port-forwarding": ""}
+	client := dialTestGateway(t, address, newCertSigner(t, userCaSigner, "bob", extensions), "bob")
+	defer func() {
+		_ = client.Close()
+	}()
+
+	// a rejected tunnel is accepted then immediately closed by the gateway,
+	// so the failure surfaces as EOF on first read
+	tunnel, err := client.Dial("tcp", "nothing.nobody:1234")
+	if err != nil {
+		return // rejected outright is also fine
+	}
+	defer func() {
+		_ = tunnel.Close()
+	}()
+	buffer := make([]byte, 1)
+	if _, err := tunnel.Read(buffer); err == nil {
+		t.Fatal("expected tunnel to unknown user to fail")
+	}
+}
+
+// TestGatewayNodeRegistration proves nodes register themselves online in the
+// database and mark themselves offline on close.
+func TestGatewayNodeRegistration(t *testing.T) {
+	t.Parallel()
+	database, release := dbtest.AcquireDatabase(t)
+	defer release()
+
+	peerCaSigner := newTestSigner(t)
+	userCaSigner := newTestSigner(t)
+	address, _, releaseNode := startTestNode(t, database, userCaSigner, peerCaSigner, "node-a", "")
+
+	node, err := database.GetNode(t.Context(), "node-a")
+	if err != nil {
+		t.Fatalf("failed to get node: %s", err)
+	}
+	if node == nil || !node.Online || node.Address != address || node.HostPublicKey == "" {
+		t.Fatalf("unexpected node registration: %+v", node)
+	}
+
+	releaseNode()
+
+	node, err = database.GetNode(t.Context(), "node-a")
+	if err != nil {
+		t.Fatalf("failed to get node: %s", err)
+	}
+	if node == nil || node.Online {
+		t.Fatalf("expected node to be offline after close, got %+v", node)
+	}
+}

--- a/gateway/peer.go
+++ b/gateway/peer.go
@@ -1,0 +1,244 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/ziyan/gatewaysshd/auth"
+	"github.com/ziyan/gatewaysshd/db"
+	"github.com/ziyan/gatewaysshd/util/deferutil"
+	"github.com/ziyan/gatewaysshd/util/sshconfig"
+)
+
+// peer represents an outbound ssh connection to another node in the mesh
+type peer struct {
+	gateway *gateway
+	nodeId  string
+	client  *ssh.Client
+
+	closeOnce sync.Once
+}
+
+func newPeer(gateway *gateway, nodeId string, client *ssh.Client) *peer {
+	return &peer{
+		gateway: gateway,
+		nodeId:  nodeId,
+		client:  client,
+	}
+}
+
+func (self *peer) String() string {
+	return fmt.Sprintf("peer(nodeId=%q)", self.nodeId)
+}
+
+// open a channel to the peer node
+func (self *peer) openTunnel(channelType string, extraData []byte, metadata map[string]interface{}) (*tunnel, error) {
+	channel, requests, err := self.client.OpenChannel(channelType, extraData)
+	if err != nil {
+		return nil, err
+	}
+
+	tunnel := newTunnel(nil, channel, channelType, extraData, metadata)
+	go func() {
+		defer deferutil.Recover()
+		tunnel.handleRequests(requests)
+	}()
+	return tunnel, nil
+}
+
+func (self *peer) ping() error {
+	if _, _, err := self.client.SendRequest("keepalive@gatewaysshd", true, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (self *peer) close() {
+	self.closeOnce.Do(func() {
+		if err := self.client.Close(); err != nil {
+			log.Debugf("%s: failed to close client: %s", self, err)
+		}
+	})
+}
+
+// checkPinnedHostKey accepts the remote host key when it, or the key embedded
+// in its certificate, matches the pinned public key. Peer nodes have host
+// certificates signed by their own certificate authority which this node does
+// not necessarily trust, so the key itself is pinned from the node record.
+func checkPinnedHostKey(pinned ssh.PublicKey) ssh.HostKeyCallback {
+	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		if certificate, ok := key.(*ssh.Certificate); ok {
+			key = certificate.Key
+		}
+		if !bytes.Equal(key.Marshal(), pinned.Marshal()) {
+			return fmt.Errorf("gateway: host key mismatch for peer %s", hostname)
+		}
+		return nil
+	}
+}
+
+// register this node in the database so other nodes can discover it
+func (self *gateway) registerNode(ctx context.Context, online bool) error {
+	if self.settings.NodeID == "" {
+		return nil
+	}
+	hostPublicKey := ""
+	if self.settings.HostPublicKey != nil {
+		hostPublicKey = string(ssh.MarshalAuthorizedKey(self.settings.HostPublicKey))
+	}
+	now := time.Now().In(time.Local)
+	if _, err := self.database.PutNode(ctx, self.settings.NodeID, func(node *db.Node) error {
+		node.Address = self.settings.NodeAddress
+		node.HostPublicKey = hostPublicKey
+		node.Online = online
+		node.OnlineAt = now
+		return nil
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// discover other online nodes from the database and connect to them
+func (self *gateway) discoverPeers(ctx context.Context) error {
+	if self.settings.NodeSigner == nil {
+		return nil // outbound peering disabled
+	}
+	nodes, err := self.database.ListNodes(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, node := range nodes {
+		if !node.Online || node.Address == "" || node.ID == self.settings.NodeID {
+			continue // cannot connect
+		}
+		if self.getPeer(node.ID) != nil {
+			continue // already connected
+		}
+		self.waitGroup.Add(1)
+		go func() {
+			defer deferutil.Recover()
+			defer self.waitGroup.Done()
+			self.connectToPeer(node)
+		}()
+	}
+
+	return nil
+}
+
+func (self *gateway) connectToPeer(node *db.Node) {
+	pinnedHostKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(node.HostPublicKey))
+	if err != nil {
+		log.Warningf("failed to parse host public key of peer %s: %s", node.ID, err)
+		return
+	}
+
+	config := &ssh.ClientConfig{
+		User: auth.PeerUser,
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(self.settings.NodeSigner),
+		},
+		HostKeyCallback: checkPinnedHostKey(pinnedHostKey),
+		Timeout:         10 * time.Second,
+	}
+	sshconfig.ApplySSHCryptoConfig(&config.Config)
+
+	client, err := ssh.Dial("tcp", node.Address, config)
+	if err != nil {
+		log.Warningf("failed to connect to peer %s at %s: %s", node.ID, node.Address, err)
+		return
+	}
+	peer := newPeer(self, node.ID, client)
+
+	// add to peers map
+	if !self.addPeer(peer) {
+		peer.close() // already connected, close this new connection
+		return
+	}
+
+	// remove from peers map at the end
+	defer self.removePeer(peer)
+	defer peer.close()
+
+	// wait until connection is done
+	log.Noticef("connected to peer %s at %s", node.ID, node.Address)
+	err = client.Wait()
+	log.Noticef("peer connection to %s at %s closed: %s", node.ID, node.Address, err)
+}
+
+func (self *gateway) runPeers(ctx context.Context) {
+	interval := self.settings.PeerDiscoveryInterval
+	if interval <= 0 {
+		interval = 15 * time.Second
+	}
+	if err := self.discoverPeers(ctx); err != nil {
+		log.Warningf("failed to discover peers: %s", err)
+	}
+	for {
+		select {
+		case <-self.done:
+			return
+		case <-time.After(interval):
+			if err := self.registerNode(ctx, true); err != nil {
+				log.Warningf("failed to register node: %s", err)
+			}
+			if err := self.discoverPeers(ctx); err != nil {
+				log.Warningf("failed to discover peers: %s", err)
+			}
+			for _, peer := range self.listPeers() {
+				if err := peer.ping(); err != nil {
+					log.Warningf("failed to ping peer node %q: %s", peer.nodeId, err)
+					continue
+				}
+			}
+		}
+	}
+}
+
+// returns a list of peers
+func (self *gateway) listPeers() []*peer {
+	self.peersLock.Lock()
+	defer self.peersLock.Unlock()
+
+	peers := make([]*peer, 0, len(self.peers))
+	for _, peer := range self.peers {
+		peers = append(peers, peer)
+	}
+	return peers
+}
+
+func (self *gateway) getPeer(nodeId string) *peer {
+	self.peersLock.Lock()
+	defer self.peersLock.Unlock()
+
+	return self.peers[nodeId]
+}
+
+func (self *gateway) addPeer(peer *peer) bool {
+	self.peersLock.Lock()
+	defer self.peersLock.Unlock()
+
+	if _, ok := self.peers[peer.nodeId]; ok {
+		return false
+	}
+	self.peers[peer.nodeId] = peer
+	return true
+}
+
+func (self *gateway) removePeer(peer *peer) bool {
+	self.peersLock.Lock()
+	defer self.peersLock.Unlock()
+
+	if self.peers[peer.nodeId] == peer {
+		delete(self.peers, peer.nodeId)
+		return true
+	}
+	return false
+}

--- a/gateway/peer.go
+++ b/gateway/peer.go
@@ -64,8 +64,10 @@ func (self *peer) close() {
 	})
 }
 
-// register this node in the database so other nodes can discover it
-func (self *gateway) registerNode(ctx context.Context, online bool) error {
+// register this node in the database so other nodes can discover it. forceTime
+// stamps OnlineAt unconditionally, used at startup so a restart after an
+// unclean shutdown (row still Online=true) still records the new online time.
+func (self *gateway) registerNode(ctx context.Context, online, forceTime bool) error {
 	if self.settings.NodeID == "" {
 		return nil
 	}
@@ -77,9 +79,9 @@ func (self *gateway) registerNode(ctx context.Context, online bool) error {
 	if _, err := self.database.PutNode(ctx, self.settings.NodeID, func(node *db.Node) error {
 		node.Address = self.settings.NodeAddress
 		node.HostPublicKey = hostPublicKey
-		// OnlineAt marks when the online state last changed, so only stamp it
-		// on a transition instead of every heartbeat
-		if node.Online != online || node.OnlineAt.IsZero() {
+		// OnlineAt marks when the online state last changed, so only stamp it on
+		// a transition (or when forced at startup) instead of every heartbeat
+		if forceTime || node.Online != online || node.OnlineAt.IsZero() {
 			node.OnlineAt = now
 		}
 		node.Online = online
@@ -145,11 +147,15 @@ func (self *gateway) connectToPeer(node *db.Node) {
 	defer peer.close()
 
 	// close the peer when the gateway shuts down so client.Wait() below
-	// unblocks even for a peer registered after Close()'s snapshot
+	// unblocks even for a peer registered after Close()'s snapshot. tracked in
+	// the waitGroup (connectToPeer holds a token throughout, so Add cannot race
+	// Wait at zero) so Close()'s barrier awaits it too.
 	watchDone := make(chan struct{})
 	defer close(watchDone)
+	self.waitGroup.Add(1)
 	go func() {
 		defer deferutil.Recover()
+		defer self.waitGroup.Done()
 		select {
 		case <-self.done:
 			peer.close()
@@ -176,7 +182,7 @@ func (self *gateway) runPeers(ctx context.Context) {
 		case <-self.done:
 			return
 		case <-time.After(interval):
-			if err := self.registerNode(ctx, true); err != nil {
+			if err := self.registerNode(ctx, true, false); err != nil {
 				log.Warningf("failed to register node: %s", err)
 			}
 			if err := self.discoverPeers(ctx); err != nil {

--- a/gateway/peer.go
+++ b/gateway/peer.go
@@ -1,16 +1,13 @@
 package gateway
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"net"
 	"sync"
 	"time"
 
 	"golang.org/x/crypto/ssh"
 
-	"github.com/ziyan/gatewaysshd/auth"
 	"github.com/ziyan/gatewaysshd/db"
 	"github.com/ziyan/gatewaysshd/util/deferutil"
 	"github.com/ziyan/gatewaysshd/util/sshconfig"
@@ -67,22 +64,6 @@ func (self *peer) close() {
 	})
 }
 
-// checkPinnedHostKey accepts the remote host key when it, or the key embedded
-// in its certificate, matches the pinned public key. Peer nodes have host
-// certificates signed by their own certificate authority which this node does
-// not necessarily trust, so the key itself is pinned from the node record.
-func checkPinnedHostKey(pinned ssh.PublicKey) ssh.HostKeyCallback {
-	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
-		if certificate, ok := key.(*ssh.Certificate); ok {
-			key = certificate.Key
-		}
-		if !bytes.Equal(key.Marshal(), pinned.Marshal()) {
-			return fmt.Errorf("gateway: host key mismatch for peer %s", hostname)
-		}
-		return nil
-	}
-}
-
 // register this node in the database so other nodes can discover it
 func (self *gateway) registerNode(ctx context.Context, online bool) error {
 	if self.settings.NodeID == "" {
@@ -96,8 +77,12 @@ func (self *gateway) registerNode(ctx context.Context, online bool) error {
 	if _, err := self.database.PutNode(ctx, self.settings.NodeID, func(node *db.Node) error {
 		node.Address = self.settings.NodeAddress
 		node.HostPublicKey = hostPublicKey
+		// OnlineAt marks when the online state last changed, so only stamp it
+		// on a transition instead of every heartbeat
+		if node.Online != online || node.OnlineAt.IsZero() {
+			node.OnlineAt = now
+		}
 		node.Online = online
-		node.OnlineAt = now
 		return nil
 	}); err != nil {
 		return err
@@ -140,15 +125,7 @@ func (self *gateway) connectToPeer(node *db.Node) {
 		return
 	}
 
-	config := &ssh.ClientConfig{
-		User: auth.PeerUser,
-		Auth: []ssh.AuthMethod{
-			ssh.PublicKeys(self.settings.NodeSigner),
-		},
-		HostKeyCallback: checkPinnedHostKey(pinnedHostKey),
-		Timeout:         10 * time.Second,
-	}
-	sshconfig.ApplySSHCryptoConfig(&config.Config)
+	config := sshconfig.NewPeerClientConfig(self.settings.NodeSigner, pinnedHostKey)
 
 	client, err := ssh.Dial("tcp", node.Address, config)
 	if err != nil {
@@ -166,6 +143,19 @@ func (self *gateway) connectToPeer(node *db.Node) {
 	// remove from peers map at the end
 	defer self.removePeer(peer)
 	defer peer.close()
+
+	// close the peer when the gateway shuts down so client.Wait() below
+	// unblocks even for a peer registered after Close()'s snapshot
+	watchDone := make(chan struct{})
+	defer close(watchDone)
+	go func() {
+		defer deferutil.Recover()
+		select {
+		case <-self.done:
+			peer.close()
+		case <-watchDone:
+		}
+	}()
 
 	// wait until connection is done
 	log.Noticef("connected to peer %s at %s", node.ID, node.Address)
@@ -194,8 +184,11 @@ func (self *gateway) runPeers(ctx context.Context) {
 			}
 			for _, peer := range self.listPeers() {
 				if err := peer.ping(); err != nil {
-					log.Warningf("failed to ping peer node %q: %s", peer.nodeId, err)
-					continue
+					// evict the dead peer so the next discovery reconnects it,
+					// otherwise getPeer keeps returning a broken connection
+					log.Warningf("evicting unresponsive peer node %q: %s", peer.nodeId, err)
+					self.removePeer(peer)
+					peer.close()
 				}
 			}
 		}
@@ -232,13 +225,11 @@ func (self *gateway) addPeer(peer *peer) bool {
 	return true
 }
 
-func (self *gateway) removePeer(peer *peer) bool {
+func (self *gateway) removePeer(peer *peer) {
 	self.peersLock.Lock()
 	defer self.peersLock.Unlock()
 
 	if self.peers[peer.nodeId] == peer {
 		delete(self.peers, peer.nodeId)
-		return true
 	}
-	return false
 }

--- a/gateway/proxy_integration_test.go
+++ b/gateway/proxy_integration_test.go
@@ -1,0 +1,260 @@
+package gateway_test
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/ziyan/gatewaysshd/gateway"
+	"github.com/ziyan/gatewaysshd/util/deferutil"
+)
+
+// exposeEchoService connects the given client to the gateway and advertises an
+// echo service on host:port, so proxy tests have something to reach.
+func exposeEchoService(t *testing.T, client *ssh.Client, host string, port uint32) {
+	t.Helper()
+	forwarded := client.HandleChannelOpen("forwarded-tcpip")
+	go func() {
+		defer deferutil.Recover()
+		for newChannel := range forwarded {
+			channel, requests, err := newChannel.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer deferutil.Recover()
+				ssh.DiscardRequests(requests)
+			}()
+			go func() {
+				defer deferutil.Recover()
+				defer func() {
+					_ = channel.Close()
+				}()
+				_, _ = io.Copy(channel, channel)
+			}()
+		}
+	}()
+
+	payload := ssh.Marshal(&struct {
+		Host string
+		Port uint32
+	}{Host: host, Port: port})
+	ok, _, err := client.SendRequest("tcpip-forward", true, payload)
+	if err != nil || !ok {
+		t.Fatalf("tcpip-forward failed: ok = %v, err = %v", ok, err)
+	}
+}
+
+// startSocksProxy starts a socks5 listener served by the gateway and returns
+// its address and a cleanup func.
+func startSocksProxy(t *testing.T, instance gateway.Gateway) (string, func()) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %s", err)
+	}
+	go func() {
+		defer deferutil.Recover()
+		for {
+			socket, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer deferutil.Recover()
+				instance.HandleSocksConnection(socket)
+			}()
+		}
+	}()
+	return listener.Addr().String(), func() {
+		_ = listener.Close()
+	}
+}
+
+// socksConnect performs a socks5 CONNECT handshake to host:port through the
+// proxy and returns the established connection.
+func socksConnect(t *testing.T, proxyAddress, host string, port uint16) net.Conn {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp", proxyAddress, 10*time.Second)
+	if err != nil {
+		t.Fatalf("failed to dial socks proxy: %s", err)
+	}
+
+	// method negotiation: version 5, one method, no-auth
+	if _, err := conn.Write([]byte{0x05, 0x01, 0x00}); err != nil {
+		t.Fatalf("failed to write socks methods: %s", err)
+	}
+	reply := make([]byte, 2)
+	if _, err := io.ReadFull(conn, reply); err != nil {
+		t.Fatalf("failed to read socks method reply: %s", err)
+	}
+	if reply[0] != 0x05 || reply[1] != 0x00 {
+		t.Fatalf("unexpected socks method reply: %v", reply)
+	}
+
+	// CONNECT request with a domain-name address
+	hostLength := byte(len(host)) // #nosec G115 - test host is short
+	request := []byte{0x05, 0x01, 0x00, 0x03, hostLength}
+	request = append(request, []byte(host)...)
+	request = binary.BigEndian.AppendUint16(request, port)
+	if _, err := conn.Write(request); err != nil {
+		t.Fatalf("failed to write socks request: %s", err)
+	}
+
+	// reply: version, rep, rsv, atyp(ipv4), 4-byte address, 2-byte port
+	response := make([]byte, 10)
+	if _, err := io.ReadFull(conn, response); err != nil {
+		t.Fatalf("failed to read socks reply: %s", err)
+	}
+	if response[1] != 0x00 {
+		_ = conn.Close()
+		t.Fatalf("socks connect failed with reply code %d", response[1])
+	}
+	return conn
+}
+
+func TestGatewaySocksProxy(t *testing.T) {
+	t.Parallel()
+	address, caSigner, instance, _, release := startTestGateway(t)
+	defer release()
+
+	proxyAddress, closeProxy := startSocksProxy(t, instance)
+	defer closeProxy()
+
+	extensions := map[string]string{"permit-port-forwarding": ""}
+	alice := dialTestGateway(t, address, newCertSigner(t, caSigner, "alice", extensions), "alice")
+	defer func() {
+		_ = alice.Close()
+	}()
+	exposeEchoService(t, alice, "myservice", 8000)
+
+	conn := socksConnect(t, proxyAddress, "myservice.alice", 8000)
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	message := []byte("hello through socks")
+	if _, err := conn.Write(message); err != nil {
+		t.Fatalf("failed to write: %s", err)
+	}
+	echo := make([]byte, len(message))
+	if _, err := io.ReadFull(conn, echo); err != nil {
+		t.Fatalf("failed to read: %s", err)
+	}
+	if !bytes.Equal(echo, message) {
+		t.Fatalf("expected %q, got %q", message, echo)
+	}
+}
+
+func TestGatewaySocksProxyUnknownService(t *testing.T) {
+	t.Parallel()
+	_, _, instance, _, release := startTestGateway(t)
+	defer release()
+
+	proxyAddress, closeProxy := startSocksProxy(t, instance)
+	defer closeProxy()
+
+	// a socks CONNECT to an unknown service must return a non-success reply
+	conn, err := net.DialTimeout("tcp", proxyAddress, 10*time.Second)
+	if err != nil {
+		t.Fatalf("failed to dial socks proxy: %s", err)
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+	if _, err := conn.Write([]byte{0x05, 0x01, 0x00}); err != nil {
+		t.Fatalf("failed to write methods: %s", err)
+	}
+	if _, err := io.ReadFull(conn, make([]byte, 2)); err != nil {
+		t.Fatalf("failed to read method reply: %s", err)
+	}
+	host := "nothing.nobody"
+	hostLength := byte(len(host)) // #nosec G115 - test host is short
+	request := append([]byte{0x05, 0x01, 0x00, 0x03, hostLength}, []byte(host)...)
+	request = binary.BigEndian.AppendUint16(request, 1234)
+	if _, err := conn.Write(request); err != nil {
+		t.Fatalf("failed to write request: %s", err)
+	}
+	response := make([]byte, 10)
+	if _, err := io.ReadFull(conn, response); err != nil {
+		t.Fatalf("failed to read reply: %s", err)
+	}
+	if response[1] == 0x00 {
+		t.Fatal("expected socks connect to unknown service to fail")
+	}
+}
+
+func TestGatewayHTTPConnectProxy(t *testing.T) {
+	t.Parallel()
+	address, caSigner, instance, _, release := startTestGateway(t)
+	defer release()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %s", err)
+	}
+	proxyServer := &http.Server{Handler: instance.HTTPProxyHandler(), ReadHeaderTimeout: 10 * time.Second}
+	go func() {
+		defer deferutil.Recover()
+		_ = proxyServer.Serve(listener)
+	}()
+	defer func() {
+		_ = proxyServer.Close()
+	}()
+
+	extensions := map[string]string{"permit-port-forwarding": ""}
+	alice := dialTestGateway(t, address, newCertSigner(t, caSigner, "alice", extensions), "alice")
+	defer func() {
+		_ = alice.Close()
+	}()
+	exposeEchoService(t, alice, "myservice", 8000)
+
+	// send an HTTP CONNECT to the proxy, then use the tunnel as raw tcp
+	conn, err := net.DialTimeout("tcp", listener.Addr().String(), 10*time.Second)
+	if err != nil {
+		t.Fatalf("failed to dial http proxy: %s", err)
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+	if _, err := conn.Write([]byte("CONNECT myservice.alice:8000 HTTP/1.1\r\nHost: myservice.alice:8000\r\n\r\n")); err != nil {
+		t.Fatalf("failed to write CONNECT: %s", err)
+	}
+	reader := bufio.NewReader(conn)
+	statusLine, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("failed to read CONNECT response: %s", err)
+	}
+	if !bytes.Contains([]byte(statusLine), []byte("200")) {
+		t.Fatalf("unexpected CONNECT response: %q", statusLine)
+	}
+	// consume the rest of the response headers
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("failed to read headers: %s", err)
+		}
+		if line == "\r\n" || line == "\n" {
+			break
+		}
+	}
+
+	message := []byte("hello through connect")
+	if _, err := conn.Write(message); err != nil {
+		t.Fatalf("failed to write: %s", err)
+	}
+	echo := make([]byte, len(message))
+	if _, err := io.ReadFull(reader, echo); err != nil {
+		t.Fatalf("failed to read echo: %s", err)
+	}
+	if !bytes.Equal(echo, message) {
+		t.Fatalf("expected %q, got %q", message, echo)
+	}
+}

--- a/gateway/proxy_integration_test.go
+++ b/gateway/proxy_integration_test.go
@@ -4,14 +4,18 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 
 	"golang.org/x/crypto/ssh"
 
+	"github.com/ziyan/gatewaysshd/db/dbtest"
 	"github.com/ziyan/gatewaysshd/gateway"
 	"github.com/ziyan/gatewaysshd/util/deferutil"
 )
@@ -19,6 +23,34 @@ import (
 // exposeEchoService connects the given client to the gateway and advertises an
 // echo service on host:port, so proxy tests have something to reach.
 func exposeEchoService(t *testing.T, client *ssh.Client, host string, port uint32) {
+	t.Helper()
+	serveForwarded(t, client, host, port, func(channel ssh.Channel) {
+		_, _ = io.Copy(channel, channel)
+	})
+}
+
+// exposeHttpService advertises an http service on host:port that answers every
+// request with a canned 200 response carrying body.
+func exposeHttpService(t *testing.T, client *ssh.Client, host string, port uint32, body string) {
+	t.Helper()
+	serveForwarded(t, client, host, port, func(channel ssh.Channel) {
+		reader := bufio.NewReader(channel)
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				return
+			}
+			if line == "\r\n" || line == "\n" {
+				break
+			}
+		}
+		_, _ = fmt.Fprintf(channel, "HTTP/1.1 200 OK\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(body), body)
+	})
+}
+
+// serveForwarded advertises host:port and runs handle on each accepted
+// forwarded-tcpip channel.
+func serveForwarded(t *testing.T, client *ssh.Client, host string, port uint32, handle func(ssh.Channel)) {
 	t.Helper()
 	forwarded := client.HandleChannelOpen("forwarded-tcpip")
 	go func() {
@@ -37,7 +69,7 @@ func exposeEchoService(t *testing.T, client *ssh.Client, host string, port uint3
 				defer func() {
 					_ = channel.Close()
 				}()
-				_, _ = io.Copy(channel, channel)
+				handle(channel)
 			}()
 		}
 	}()
@@ -78,25 +110,45 @@ func startSocksProxy(t *testing.T, instance gateway.Gateway) (string, func()) {
 	}
 }
 
-// socksConnect performs a socks5 CONNECT handshake to host:port through the
-// proxy and returns the established connection.
-func socksConnect(t *testing.T, proxyAddress, host string, port uint16) net.Conn {
+// startHttpProxy starts an http forward-proxy listener served by the gateway.
+func startHttpProxy(t *testing.T, instance gateway.Gateway) (string, func()) {
 	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %s", err)
+	}
+	server := &http.Server{Handler: instance.HTTPProxyHandler(), ReadHeaderTimeout: 10 * time.Second}
+	go func() {
+		defer deferutil.Recover()
+		_ = server.Serve(listener)
+	}()
+	return listener.Addr().String(), func() {
+		_ = server.Close()
+	}
+}
+
+// socksConnect performs a socks5 CONNECT handshake to host:port through the
+// proxy and returns the established connection, or an error if the proxy
+// refuses (including a non-success reply code).
+func socksConnect(proxyAddress, host string, port uint16) (net.Conn, error) {
 	conn, err := net.DialTimeout("tcp", proxyAddress, 10*time.Second)
 	if err != nil {
-		t.Fatalf("failed to dial socks proxy: %s", err)
+		return nil, err
 	}
 
 	// method negotiation: version 5, one method, no-auth
 	if _, err := conn.Write([]byte{0x05, 0x01, 0x00}); err != nil {
-		t.Fatalf("failed to write socks methods: %s", err)
+		_ = conn.Close()
+		return nil, err
 	}
 	reply := make([]byte, 2)
 	if _, err := io.ReadFull(conn, reply); err != nil {
-		t.Fatalf("failed to read socks method reply: %s", err)
+		_ = conn.Close()
+		return nil, err
 	}
 	if reply[0] != 0x05 || reply[1] != 0x00 {
-		t.Fatalf("unexpected socks method reply: %v", reply)
+		_ = conn.Close()
+		return nil, fmt.Errorf("socks method rejected: %v", reply)
 	}
 
 	// CONNECT request with a domain-name address
@@ -105,19 +157,97 @@ func socksConnect(t *testing.T, proxyAddress, host string, port uint16) net.Conn
 	request = append(request, []byte(host)...)
 	request = binary.BigEndian.AppendUint16(request, port)
 	if _, err := conn.Write(request); err != nil {
-		t.Fatalf("failed to write socks request: %s", err)
+		_ = conn.Close()
+		return nil, err
 	}
 
 	// reply: version, rep, rsv, atyp(ipv4), 4-byte address, 2-byte port
 	response := make([]byte, 10)
 	if _, err := io.ReadFull(conn, response); err != nil {
-		t.Fatalf("failed to read socks reply: %s", err)
+		_ = conn.Close()
+		return nil, err
 	}
 	if response[1] != 0x00 {
 		_ = conn.Close()
-		t.Fatalf("socks connect failed with reply code %d", response[1])
+		return nil, fmt.Errorf("socks connect failed with reply code %d", response[1])
 	}
-	return conn
+	return conn, nil
+}
+
+// socksRoundTrip connects through the socks proxy and echoes message.
+func socksRoundTrip(proxyAddress, host string, port uint16, message []byte) ([]byte, error) {
+	conn, err := socksConnect(proxyAddress, host, port)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+	return writeThenRead(conn, conn, message)
+}
+
+// httpConnectRoundTrip tunnels to target via an http CONNECT and echoes message.
+func httpConnectRoundTrip(proxyAddress, target string, message []byte) ([]byte, error) {
+	conn, err := net.DialTimeout("tcp", proxyAddress, 10*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	if _, err := fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target); err != nil {
+		return nil, err
+	}
+	reader := bufio.NewReader(conn)
+	statusLine, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	if !strings.Contains(statusLine, "200") {
+		return nil, fmt.Errorf("connect failed: %s", strings.TrimSpace(statusLine))
+	}
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		if line == "\r\n" || line == "\n" {
+			break
+		}
+	}
+	return writeThenRead(conn, reader, message)
+}
+
+func writeThenRead(writer io.Writer, reader io.Reader, message []byte) ([]byte, error) {
+	if _, err := writer.Write(message); err != nil {
+		return nil, err
+	}
+	echo := make([]byte, len(message))
+	if _, err := io.ReadFull(reader, echo); err != nil {
+		return nil, err
+	}
+	return echo, nil
+}
+
+// retryEcho retries the round trip until it succeeds or the deadline passes,
+// so mesh tests tolerate peer discovery latency.
+func retryEcho(t *testing.T, message []byte, roundTrip func() ([]byte, error)) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		echo, err := roundTrip()
+		if err == nil {
+			if !bytes.Equal(echo, message) {
+				t.Fatalf("expected %q, got %q", message, echo)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("failed to echo through proxy: %s", err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
 }
 
 func TestGatewaySocksProxy(t *testing.T) {
@@ -135,18 +265,10 @@ func TestGatewaySocksProxy(t *testing.T) {
 	}()
 	exposeEchoService(t, alice, "myservice", 8000)
 
-	conn := socksConnect(t, proxyAddress, "myservice.alice", 8000)
-	defer func() {
-		_ = conn.Close()
-	}()
-
 	message := []byte("hello through socks")
-	if _, err := conn.Write(message); err != nil {
-		t.Fatalf("failed to write: %s", err)
-	}
-	echo := make([]byte, len(message))
-	if _, err := io.ReadFull(conn, echo); err != nil {
-		t.Fatalf("failed to read: %s", err)
+	echo, err := socksRoundTrip(proxyAddress, "myservice.alice", 8000, message)
+	if err != nil {
+		t.Fatalf("socks round trip failed: %s", err)
 	}
 	if !bytes.Equal(echo, message) {
 		t.Fatalf("expected %q, got %q", message, echo)
@@ -161,32 +283,8 @@ func TestGatewaySocksProxyUnknownService(t *testing.T) {
 	proxyAddress, closeProxy := startSocksProxy(t, instance)
 	defer closeProxy()
 
-	// a socks CONNECT to an unknown service must return a non-success reply
-	conn, err := net.DialTimeout("tcp", proxyAddress, 10*time.Second)
-	if err != nil {
-		t.Fatalf("failed to dial socks proxy: %s", err)
-	}
-	defer func() {
+	if conn, err := socksConnect(proxyAddress, "nothing.nobody", 1234); err == nil {
 		_ = conn.Close()
-	}()
-	if _, err := conn.Write([]byte{0x05, 0x01, 0x00}); err != nil {
-		t.Fatalf("failed to write methods: %s", err)
-	}
-	if _, err := io.ReadFull(conn, make([]byte, 2)); err != nil {
-		t.Fatalf("failed to read method reply: %s", err)
-	}
-	host := "nothing.nobody"
-	hostLength := byte(len(host)) // #nosec G115 - test host is short
-	request := append([]byte{0x05, 0x01, 0x00, 0x03, hostLength}, []byte(host)...)
-	request = binary.BigEndian.AppendUint16(request, 1234)
-	if _, err := conn.Write(request); err != nil {
-		t.Fatalf("failed to write request: %s", err)
-	}
-	response := make([]byte, 10)
-	if _, err := io.ReadFull(conn, response); err != nil {
-		t.Fatalf("failed to read reply: %s", err)
-	}
-	if response[1] == 0x00 {
 		t.Fatal("expected socks connect to unknown service to fail")
 	}
 }
@@ -196,18 +294,8 @@ func TestGatewayHTTPConnectProxy(t *testing.T) {
 	address, caSigner, instance, _, release := startTestGateway(t)
 	defer release()
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("failed to listen: %s", err)
-	}
-	proxyServer := &http.Server{Handler: instance.HTTPProxyHandler(), ReadHeaderTimeout: 10 * time.Second}
-	go func() {
-		defer deferutil.Recover()
-		_ = proxyServer.Serve(listener)
-	}()
-	defer func() {
-		_ = proxyServer.Close()
-	}()
+	proxyAddress, closeProxy := startHttpProxy(t, instance)
+	defer closeProxy()
 
 	extensions := map[string]string{"permit-port-forwarding": ""}
 	alice := dialTestGateway(t, address, newCertSigner(t, caSigner, "alice", extensions), "alice")
@@ -216,45 +304,122 @@ func TestGatewayHTTPConnectProxy(t *testing.T) {
 	}()
 	exposeEchoService(t, alice, "myservice", 8000)
 
-	// send an HTTP CONNECT to the proxy, then use the tunnel as raw tcp
-	conn, err := net.DialTimeout("tcp", listener.Addr().String(), 10*time.Second)
-	if err != nil {
-		t.Fatalf("failed to dial http proxy: %s", err)
-	}
-	defer func() {
-		_ = conn.Close()
-	}()
-	if _, err := conn.Write([]byte("CONNECT myservice.alice:8000 HTTP/1.1\r\nHost: myservice.alice:8000\r\n\r\n")); err != nil {
-		t.Fatalf("failed to write CONNECT: %s", err)
-	}
-	reader := bufio.NewReader(conn)
-	statusLine, err := reader.ReadString('\n')
-	if err != nil {
-		t.Fatalf("failed to read CONNECT response: %s", err)
-	}
-	if !bytes.Contains([]byte(statusLine), []byte("200")) {
-		t.Fatalf("unexpected CONNECT response: %q", statusLine)
-	}
-	// consume the rest of the response headers
-	for {
-		line, err := reader.ReadString('\n')
-		if err != nil {
-			t.Fatalf("failed to read headers: %s", err)
-		}
-		if line == "\r\n" || line == "\n" {
-			break
-		}
-	}
-
 	message := []byte("hello through connect")
-	if _, err := conn.Write(message); err != nil {
-		t.Fatalf("failed to write: %s", err)
-	}
-	echo := make([]byte, len(message))
-	if _, err := io.ReadFull(reader, echo); err != nil {
-		t.Fatalf("failed to read echo: %s", err)
+	echo, err := httpConnectRoundTrip(proxyAddress, "myservice.alice:8000", message)
+	if err != nil {
+		t.Fatalf("http connect round trip failed: %s", err)
 	}
 	if !bytes.Equal(echo, message) {
 		t.Fatalf("expected %q, got %q", message, echo)
 	}
+}
+
+// TestGatewayHTTPPlainProxy exercises the plain (non-CONNECT) http forward
+// proxy path, which dials the exposed service through openServiceTunnel and
+// relays the http response.
+func TestGatewayHTTPPlainProxy(t *testing.T) {
+	t.Parallel()
+	address, caSigner, instance, _, release := startTestGateway(t)
+	defer release()
+
+	proxyAddress, closeProxy := startHttpProxy(t, instance)
+	defer closeProxy()
+
+	extensions := map[string]string{"permit-port-forwarding": ""}
+	alice := dialTestGateway(t, address, newCertSigner(t, caSigner, "alice", extensions), "alice")
+	defer func() {
+		_ = alice.Close()
+	}()
+	exposeHttpService(t, alice, "web", 80, "hello from web")
+
+	proxyURL, err := url.Parse("http://" + proxyAddress)
+	if err != nil {
+		t.Fatalf("failed to parse proxy url: %s", err)
+	}
+	client := &http.Client{
+		Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)},
+		Timeout:   10 * time.Second,
+	}
+	response, err := client.Get("http://web.alice/")
+	if err != nil {
+		t.Fatalf("failed to get through http proxy: %s", err)
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("failed to read body: %s", err)
+	}
+	if string(body) != "hello from web" {
+		t.Fatalf("unexpected body: %q", body)
+	}
+}
+
+// TestGatewaySocksProxyViaMesh proves a socks proxy on one node reaches a
+// service exposed on another node through the peer connection.
+func TestGatewaySocksProxyViaMesh(t *testing.T) {
+	t.Parallel()
+	database, release := dbtest.AcquireDatabase(t)
+	defer release()
+
+	peerCaSigner := newTestSigner(t)
+	userCaSignerA := newTestSigner(t)
+	userCaSignerB := newTestSigner(t)
+
+	addressA, instanceA, releaseA := startTestNode(t, database, userCaSignerA, peerCaSigner, "node-a", "")
+	defer releaseA()
+	addressB, _, releaseB := startTestNode(t, database, userCaSignerB, peerCaSigner, "node-b", "")
+	defer releaseB()
+	_ = addressA
+
+	// alice exposes an echo service on node b
+	extensions := map[string]string{"permit-port-forwarding": ""}
+	alice := dialTestGateway(t, addressB, newCertSigner(t, userCaSignerB, "alice", extensions), "alice")
+	defer func() {
+		_ = alice.Close()
+	}()
+	exposeEchoService(t, alice, "myservice", 8000)
+
+	// the socks proxy runs on node a; reaching alice's service on node b
+	// exercises node a forwarding through its peer connection to node b
+	proxyAddress, closeProxy := startSocksProxy(t, instanceA)
+	defer closeProxy()
+
+	message := []byte("hello across the mesh via socks")
+	retryEcho(t, message, func() ([]byte, error) {
+		return socksRoundTrip(proxyAddress, "myservice.alice", 8000, message)
+	})
+}
+
+// TestGatewayHTTPConnectProxyViaMesh proves an http CONNECT proxy on one node
+// reaches a service exposed on another node through the peer connection.
+func TestGatewayHTTPConnectProxyViaMesh(t *testing.T) {
+	t.Parallel()
+	database, release := dbtest.AcquireDatabase(t)
+	defer release()
+
+	peerCaSigner := newTestSigner(t)
+	userCaSignerA := newTestSigner(t)
+	userCaSignerB := newTestSigner(t)
+
+	_, instanceA, releaseA := startTestNode(t, database, userCaSignerA, peerCaSigner, "node-a", "")
+	defer releaseA()
+	addressB, _, releaseB := startTestNode(t, database, userCaSignerB, peerCaSigner, "node-b", "")
+	defer releaseB()
+
+	extensions := map[string]string{"permit-port-forwarding": ""}
+	alice := dialTestGateway(t, addressB, newCertSigner(t, userCaSignerB, "alice", extensions), "alice")
+	defer func() {
+		_ = alice.Close()
+	}()
+	exposeEchoService(t, alice, "myservice", 8000)
+
+	proxyAddress, closeProxy := startHttpProxy(t, instanceA)
+	defer closeProxy()
+
+	message := []byte("hello across the mesh via connect")
+	retryEcho(t, message, func() ([]byte, error) {
+		return httpConnectRoundTrip(proxyAddress, "myservice.alice:8000", message)
+	})
 }

--- a/gateway/socks.go
+++ b/gateway/socks.go
@@ -1,0 +1,81 @@
+package gateway
+
+import (
+	"io"
+	"net"
+
+	"github.com/ziyan/gatewaysshd/util/deferutil"
+	"github.com/ziyan/gatewaysshd/util/socks"
+)
+
+// HandleSocksConnection serves a single SOCKS5 client. The proxy is
+// unauthenticated: any client that reaches the listener can open a tunnel to
+// any exposed service, the same reachability as an "ssh -D" dynamic forward.
+// It should therefore only be bound to a trusted network.
+func (self *gateway) HandleSocksConnection(socket net.Conn) {
+	log.Infof("socks connection accepted: remote = %s, local = %s", socket.RemoteAddr(), socket.LocalAddr())
+	defer func() {
+		if err := socket.Close(); err != nil {
+			log.Warningf("failed to close socks connection: %s", err)
+		}
+		log.Infof("socks connection closed: remote = %s", socket.RemoteAddr())
+	}()
+
+	if err := socks.Authenticate(socket); err != nil {
+		log.Warningf("failed during socks handshake: %s", err)
+		return
+	}
+
+	host, port, err := socks.ParseRequest(socket)
+	if err != nil {
+		log.Warningf("failed during socks request: %s", err)
+		return
+	}
+
+	originAddress, originPort := splitOrigin(socket.RemoteAddr())
+	tunnel, err := self.openServiceTunnel(host, port, originAddress, originPort)
+	if err != nil {
+		log.Warningf("socks: failed to open tunnel to %s:%d: %s", host, port, err)
+		_ = socks.SendReply(socket, socks.HostUnreachable)
+		return
+	}
+	defer tunnel.close()
+
+	if err := socks.SendReply(socket, socks.Succeeded); err != nil {
+		return
+	}
+
+	bridge(socket, tunnel.channel)
+}
+
+// splitOrigin extracts the ip and port of a tcp remote address for tunnel
+// origin metadata, tolerating non-tcp addresses.
+func splitOrigin(address net.Addr) (string, uint32) {
+	if tcpAddress, ok := address.(*net.TCPAddr); ok {
+		// #nosec G115 - a tcp port is always within uint32 range
+		return tcpAddress.IP.String(), uint32(tcpAddress.Port)
+	}
+	return address.String(), 0
+}
+
+// bridge copies bytes in both directions until either side closes.
+func bridge(left io.ReadWriter, right io.ReadWriter) {
+	done1 := make(chan struct{})
+	go func() {
+		defer deferutil.Recover()
+		defer close(done1)
+		_, _ = io.Copy(left, right)
+	}()
+
+	done2 := make(chan struct{})
+	go func() {
+		defer deferutil.Recover()
+		defer close(done2)
+		_, _ = io.Copy(right, left)
+	}()
+
+	select {
+	case <-done1:
+	case <-done2:
+	}
+}

--- a/gateway/tunnel.go
+++ b/gateway/tunnel.go
@@ -21,7 +21,6 @@ type tunnel struct {
 }
 
 func newTunnel(connection *connection, channel ssh.Channel, channelType string, extraData []byte, metadata map[string]interface{}) *tunnel {
-	log.Infof("%s: new tunnel: type = %s, metadata = %v", connection, channelType, metadata)
 	self := &tunnel{
 		connection:  connection,
 		channel:     channel,
@@ -30,8 +29,19 @@ func newTunnel(connection *connection, channel ssh.Channel, channelType string, 
 		done:        make(chan struct{}),
 		metadata:    metadata,
 	}
-	connection.addTunnel(self)
+	log.Infof("%s: new tunnel: type = %s, metadata = %v", self.owner(), channelType, metadata)
+	if connection != nil {
+		connection.addTunnel(self)
+	}
 	return self
+}
+
+// owner describes where the tunnel came from, peer tunnels have no connection
+func (self *tunnel) owner() string {
+	if self.connection != nil {
+		return self.connection.String()
+	}
+	return "peer"
 }
 
 // close the tunnel
@@ -43,11 +53,13 @@ func (self *tunnel) close() {
 
 func (self *tunnel) handleRequests(requests <-chan *ssh.Request) {
 	defer func() {
-		self.connection.deleteTunnel(self)
-		if err := self.channel.Close(); err != nil {
-			log.Warningf("%s: failed to close tunnel: %s", self.connection, err)
+		if self.connection != nil {
+			self.connection.deleteTunnel(self)
 		}
-		log.Infof("%s: tunnel closed: type = %s, metadata = %v", self.connection, self.channelType, self.metadata)
+		if err := self.channel.Close(); err != nil {
+			log.Warningf("%s: failed to close tunnel: %s", self.owner(), err)
+		}
+		log.Infof("%s: tunnel closed: type = %s, metadata = %v", self.owner(), self.channelType, self.metadata)
 	}()
 
 	for {
@@ -62,7 +74,7 @@ func (self *tunnel) handleRequests(requests <-chan *ssh.Request) {
 			// reply to client
 			if request.WantReply {
 				if err := request.Reply(false, nil); err != nil {
-					log.Errorf("%s: failed to reply to request: %s", self.connection, err)
+					log.Errorf("%s: failed to reply to request: %s", self.owner(), err)
 					return
 				}
 			}

--- a/gateway/tunnel.go
+++ b/gateway/tunnel.go
@@ -9,6 +9,14 @@ import (
 	"github.com/ziyan/gatewaysshd/util/deferutil"
 )
 
+// tunnelOpener is a target a tunnel can be forwarded to: either a local
+// connection or a remote peer node. Both expose the same channel-open surface,
+// so mesh and single-node forwarding share one code path.
+type tunnelOpener interface {
+	openTunnel(channelType string, extraData []byte, metadata map[string]interface{}) (*tunnel, error)
+	String() string
+}
+
 // a tunnel within a ssh connection
 type tunnel struct {
 	connection  *connection

--- a/gateway/utils.go
+++ b/gateway/utils.go
@@ -88,17 +88,22 @@ func marshalTunnelData(data *tunnelData) []byte {
 // 	return request, nil
 // }
 
+// usageStats is written concurrently by a connection's ssh read and write
+// loops and read by gatherStatus/getUsedAt, so every mutable field is accessed
+// atomically. The 64-bit atomic fields are declared first for alignment on
+// 32-bit platforms. createdAt is immutable after construction.
 type usageStats struct {
 	bytesRead    uint64
 	bytesWritten uint64
+	usedAtNano   int64
 	createdAt    time.Time
-	usedAt       time.Time
 }
 
 func newUsage() *usageStats {
+	now := time.Now()
 	return &usageStats{
-		createdAt: time.Now(),
-		usedAt:    time.Now(),
+		createdAt:  now,
+		usedAtNano: now.UnixNano(),
 	}
 }
 
@@ -110,10 +115,6 @@ func (self *usageStats) write(bytesWritten uint64) {
 	self.update(0, bytesWritten)
 }
 
-// func (self *usageStats) use() {
-// 	self.update(0, 0)
-// }
-
 func (self *usageStats) update(bytesRead, bytesWritten uint64) {
 	if bytesRead > 0 {
 		atomic.AddUint64(&self.bytesRead, bytesRead)
@@ -121,7 +122,19 @@ func (self *usageStats) update(bytesRead, bytesWritten uint64) {
 	if bytesWritten > 0 {
 		atomic.AddUint64(&self.bytesWritten, bytesWritten)
 	}
-	self.usedAt = time.Now()
+	atomic.StoreInt64(&self.usedAtNano, time.Now().UnixNano())
+}
+
+func (self *usageStats) getBytesRead() uint64 {
+	return atomic.LoadUint64(&self.bytesRead)
+}
+
+func (self *usageStats) getBytesWritten() uint64 {
+	return atomic.LoadUint64(&self.bytesWritten)
+}
+
+func (self *usageStats) getUsedAt() time.Time {
+	return time.Unix(0, atomic.LoadInt64(&self.usedAtNano))
 }
 
 type wrappedConn struct {

--- a/gateway/utils_test.go
+++ b/gateway/utils_test.go
@@ -81,20 +81,20 @@ func TestTunnelDataRejectsInvalidPorts(t *testing.T) {
 
 func TestUsageStatsUpdate(t *testing.T) {
 	usage := newUsage()
-	before := usage.usedAt
+	before := usage.getUsedAt()
 
 	usage.read(100)
 	usage.write(25)
 	usage.update(3, 4)
 
-	if usage.bytesRead != 103 {
-		t.Fatalf("expected 103 bytes read, got %d", usage.bytesRead)
+	if usage.getBytesRead() != 103 {
+		t.Fatalf("expected 103 bytes read, got %d", usage.getBytesRead())
 	}
-	if usage.bytesWritten != 29 {
-		t.Fatalf("expected 29 bytes written, got %d", usage.bytesWritten)
+	if usage.getBytesWritten() != 29 {
+		t.Fatalf("expected 29 bytes written, got %d", usage.getBytesWritten())
 	}
-	if usage.usedAt.Before(before) {
-		t.Fatalf("expected usedAt to advance, got %s < %s", usage.usedAt, before)
+	if usage.getUsedAt().Before(before) {
+		t.Fatalf("expected usedAt to advance, got %s < %s", usage.getUsedAt(), before)
 	}
 }
 

--- a/mulint.yaml
+++ b/mulint.yaml
@@ -1,1 +1,5 @@
-# Project-specific extensions to the mulint defaults. Defaults are used as-is.
+# Project-specific extensions to the mulint defaults.
+extra:
+  acronyms:
+    # certificate authority
+    - CA

--- a/util/socks/socks.go
+++ b/util/socks/socks.go
@@ -1,0 +1,147 @@
+// Package socks implements the parts of the SOCKS protocol version 5 needed to
+// accept CONNECT requests. See https://tools.ietf.org/html/rfc1928.
+package socks
+
+import (
+	"errors"
+	"io"
+	"net"
+
+	logging "github.com/op/go-logging"
+)
+
+const (
+	socksVersion = byte(5)
+
+	noAuthRequired     = byte(0)
+	noAcceptableMethod = byte(255)
+
+	connectCommand = byte(1)
+
+	ipv4AddressType       = byte(1)
+	domainNameAddressType = byte(3)
+	ipv6AddressType       = byte(4)
+)
+
+// Reply is a SOCKS5 reply code.
+type Reply byte
+
+const (
+	Succeeded               = Reply(0)
+	ServerFailure           = Reply(1)
+	NotAllowed              = Reply(2)
+	NetworkUnreachable      = Reply(3)
+	HostUnreachable         = Reply(4)
+	ConnectionRefused       = Reply(5)
+	TTLExpired              = Reply(6)
+	CommandNotSupported     = Reply(7)
+	AddressTypeNotSupported = Reply(8)
+)
+
+var (
+	ErrUnsupportedVersion = errors.New("socks: unsupported version")
+	ErrUnsupportedAuth    = errors.New("socks: unsupported auth")
+	ErrUnsupportedAddress = errors.New("socks: unsupported address")
+	ErrUnsupportedCommand = errors.New("socks: unsupported command")
+)
+
+var log = logging.MustGetLogger("socks")
+
+// Authenticate performs the SOCKS5 method negotiation, accepting only the
+// no-authentication method (the proxy itself is unauthenticated).
+func Authenticate(conn net.Conn) error {
+	header := []byte{0, 0}
+	if _, err := io.ReadFull(conn, header); err != nil {
+		return err
+	}
+	if header[0] != socksVersion {
+		log.Errorf("received invalid version: %v", header[0])
+		return ErrUnsupportedVersion
+	}
+	methods := make([]byte, int(header[1]))
+	if _, err := io.ReadFull(conn, methods); err != nil {
+		return err
+	}
+	for _, method := range methods {
+		if method == noAuthRequired {
+			if _, err := conn.Write([]byte{socksVersion, noAuthRequired}); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+	log.Errorf("no authentication method acceptable: %v", methods)
+	_, _ = conn.Write([]byte{socksVersion, noAcceptableMethod})
+	return ErrUnsupportedAuth
+}
+
+// ParseRequest reads a SOCKS5 request and returns the requested host and port.
+// Only the CONNECT command is supported. IPv4, IPv6, and domain-name address
+// types are all accepted; the returned host is the literal address string.
+func ParseRequest(conn net.Conn) (string, uint16, error) {
+	header := []byte{0, 0, 0, 0}
+	if _, err := io.ReadFull(conn, header); err != nil {
+		return "", 0, err
+	}
+	if header[0] != socksVersion {
+		log.Errorf("received invalid version: %v", header[0])
+		return "", 0, ErrUnsupportedVersion
+	}
+
+	var address string
+	switch header[3] {
+	case domainNameAddressType:
+		length := []byte{0}
+		if _, err := io.ReadFull(conn, length); err != nil {
+			return "", 0, err
+		}
+		addressBytes := make([]byte, int(length[0]))
+		if _, err := io.ReadFull(conn, addressBytes); err != nil {
+			return "", 0, err
+		}
+		address = string(addressBytes)
+	case ipv4AddressType:
+		addressBytes := make([]byte, net.IPv4len)
+		if _, err := io.ReadFull(conn, addressBytes); err != nil {
+			return "", 0, err
+		}
+		address = net.IP(addressBytes).String()
+	case ipv6AddressType:
+		addressBytes := make([]byte, net.IPv6len)
+		if _, err := io.ReadFull(conn, addressBytes); err != nil {
+			return "", 0, err
+		}
+		address = net.IP(addressBytes).String()
+	default:
+		return "", 0, ErrUnsupportedAddress
+	}
+
+	portBytes := []byte{0, 0}
+	if _, err := io.ReadFull(conn, portBytes); err != nil {
+		return "", 0, err
+	}
+	port := (uint16(portBytes[0]) << 8) | uint16(portBytes[1])
+
+	if header[1] != connectCommand {
+		_ = SendReply(conn, CommandNotSupported)
+		return "", 0, ErrUnsupportedCommand
+	}
+
+	return address, port, nil
+}
+
+// SendReply writes a SOCKS5 reply with an all-zero bound address.
+func SendReply(conn net.Conn, reply Reply) error {
+	if _, err := conn.Write([]byte{
+		socksVersion,
+		byte(reply),
+		0,               // reserved
+		ipv4AddressType, // bound address type
+		0, 0, 0, 0,      // bound address
+		0, 0, // bound port
+	}); err != nil {
+		log.Warningf("failed to send reply on socks connection: %s", err)
+		return err
+	}
+	return nil
+}

--- a/util/sshconfig/sshconfig.go
+++ b/util/sshconfig/sshconfig.go
@@ -1,12 +1,50 @@
-// Package sshconfig keeps ssh crypto settings consistent across the application.
+// Package sshconfig keeps ssh crypto and peer client settings consistent
+// across the application.
 package sshconfig
 
 import (
+	"bytes"
+	"fmt"
+	"net"
+	"time"
+
 	logging "github.com/op/go-logging"
 	"golang.org/x/crypto/ssh"
 )
 
 var log = logging.MustGetLogger("sshconfig") //nolint:unused
+
+// PeerUser is the reserved username peer nodes authenticate with.
+const PeerUser = "peer"
+
+// CheckPinnedHostKey accepts the remote host key when it, or the key embedded
+// in its certificate, matches the pinned public key. Peer nodes have host
+// certificates signed by their own certificate authority which the dialing
+// node does not necessarily trust, so the key itself is pinned.
+func CheckPinnedHostKey(pinned ssh.PublicKey) ssh.HostKeyCallback {
+	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		if certificate, ok := key.(*ssh.Certificate); ok {
+			key = certificate.Key
+		}
+		if !bytes.Equal(key.Marshal(), pinned.Marshal()) {
+			return fmt.Errorf("sshconfig: host key mismatch for peer %s", hostname)
+		}
+		return nil
+	}
+}
+
+// NewPeerClientConfig builds the ssh client config used to authenticate to
+// another node as a peer, with the hardened crypto settings applied.
+func NewPeerClientConfig(signer ssh.Signer, pinnedHostKey ssh.PublicKey) *ssh.ClientConfig {
+	config := &ssh.ClientConfig{
+		User:            PeerUser,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		HostKeyCallback: CheckPinnedHostKey(pinnedHostKey),
+		Timeout:         10 * time.Second,
+	}
+	ApplySSHCryptoConfig(&config.Config)
+	return config
+}
 
 // ApplySSHCryptoConfig removes insecure key exchanges, ciphers, and MACs from
 // the default lists.

--- a/util/sshconfig/sshconfig.go
+++ b/util/sshconfig/sshconfig.go
@@ -1,0 +1,35 @@
+// Package sshconfig keeps ssh crypto settings consistent across the application.
+package sshconfig
+
+import (
+	logging "github.com/op/go-logging"
+	"golang.org/x/crypto/ssh"
+)
+
+var log = logging.MustGetLogger("sshconfig") //nolint:unused
+
+// ApplySSHCryptoConfig removes insecure key exchanges, ciphers, and MACs from
+// the default lists.
+func ApplySSHCryptoConfig(config *ssh.Config) {
+	config.KeyExchanges = []string{
+		ssh.KeyExchangeCurve25519,
+		ssh.KeyExchangeECDHP256,
+		ssh.KeyExchangeECDHP384,
+		ssh.KeyExchangeECDHP521,
+		ssh.KeyExchangeDH14SHA256,
+	}
+	config.Ciphers = []string{
+		ssh.CipherAES128GCM,
+		ssh.CipherAES256GCM,
+		ssh.CipherAES128CTR,
+		ssh.CipherAES192CTR,
+		ssh.CipherAES256CTR,
+	}
+	config.MACs = []string{
+		ssh.HMACSHA256ETM,
+		ssh.HMACSHA512ETM,
+		ssh.HMACSHA256,
+		ssh.HMACSHA512,
+		ssh.HMACSHA1,
+	}
+}


### PR DESCRIPTION
## Summary

Ports the peer-mesh feature from wei/backend: multiple gateway instances share one central postgres database and form a mesh over the **existing** SSH service port (no new listener). A user on one node can tunnel to a user's service on another node, and nodes without direct database access can reach postgres through a peer.

Inter-node trust is a **separate peer certificate authority** layered on top of each node's user CA, so existing single-node deployments keep their user-facing CA, host key, and service port unchanged.

<!-- changelog:start -->
### Added

- Mesh peering: gateway nodes sharing one postgres database can tunnel a user on one node to a user's service on another node over the existing SSH service port
- Separate peer certificate authority (`--peer-ca-public-key`, `--node-certificate`, `--node-id`, `--node-address`) for inter-node trust, layered on top of the user CA
- Reach the central postgres through a peer node's SSH service port (`--postgres-peer`, `--postgres-peer-host-public-key`)
- Configurable postgres sslmode (`--postgres-sslmode`)

### Changed

- `db.Open` now takes a `db.Settings` struct; `auth.NewConfig` now takes an `auth.Settings` struct
<!-- changelog:end -->

## Test plan

- `make test` (postgres-backed), including new mesh integration tests: cross-node tunnel with distinct user CAs, postgres-via-peer, peer/user CA isolation, postgres-requires-peer, unknown-user rejection, node registration lifecycle, and node CRUD
- `make lint` and `make lint-mulint` clean
