### PR TITLE
feat(cli): allow postgres password to be supplied via file

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/urfave/cli/v3"
@@ -94,6 +95,11 @@ var flags = []cli.Flag{
 		Name:  "postgres-password",
 		Value: "gatewaysshd",
 		Usage: "password to authenticate with postgres database",
+	},
+	&cli.StringFlag{
+		Name:  "postgres-password-file",
+		Value: "",
+		Usage: "path to file containing the postgres password, takes precedence over postgres-password",
 	},
 	&cli.StringFlag{
 		Name:  "postgres-dbname",
@@ -225,4 +231,18 @@ func parseHostSigner(command *cli.Command) (ssh.Signer, error) {
 
 func parseIdleTimeout(command *cli.Command) (time.Duration, error) {
 	return time.ParseDuration(command.String("idle-timeout"))
+}
+
+// parsePostgresPassword prefers the password file over the inline flag so the
+// secret can stay out of process arguments
+func parsePostgresPassword(command *cli.Command) (string, error) {
+	path := command.String("postgres-password-file")
+	if path == "" {
+		return command.String("postgres-password"), nil
+	}
+	raw, err := os.ReadFile(path) // #nosec G304 - operator-supplied password path
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(raw), "\r\n"), nil
 }

--- a/cli/flags_test.go
+++ b/cli/flags_test.go
@@ -169,3 +169,44 @@ func TestParseIdleTimeout(t *testing.T) {
 		t.Fatal("expected error for invalid duration")
 	}
 }
+
+func TestParsePostgresPasswordInline(t *testing.T) {
+	if err := runWithFlags(t, []string{"--postgres-password", "hunter2"}, func(command *cli.Command) error {
+		password, err := parsePostgresPassword(command)
+		if err != nil {
+			return err
+		}
+		if password != "hunter2" {
+			t.Fatalf("expected inline password, got %q", password)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("failed to parse postgres password: %s", err)
+	}
+}
+
+func TestParsePostgresPasswordFileTakesPrecedence(t *testing.T) {
+	path := writeTestFile(t, "password", []byte("from-file\n"))
+
+	if err := runWithFlags(t, []string{"--postgres-password", "inline", "--postgres-password-file", path}, func(command *cli.Command) error {
+		password, err := parsePostgresPassword(command)
+		if err != nil {
+			return err
+		}
+		if password != "from-file" {
+			t.Fatalf("expected password from file with trailing newline trimmed, got %q", password)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("failed to parse postgres password: %s", err)
+	}
+}
+
+func TestParsePostgresPasswordFileMissing(t *testing.T) {
+	if err := runWithFlags(t, []string{"--postgres-password-file", "/nonexistent/password"}, func(command *cli.Command) error {
+		_, err := parsePostgresPassword(command)
+		return err
+	}); err == nil {
+		t.Fatal("expected error for missing password file")
+	}
+}

--- a/cli/run.go
+++ b/cli/run.go
@@ -113,11 +113,16 @@ func run(ctx context.Context, command *cli.Command) error {
 	if pgPort > 65535 {
 		return fmt.Errorf("cli: postgres port %d is out of range (max 65535)", pgPort)
 	}
+	postgresPassword, err := parsePostgresPassword(command)
+	if err != nil {
+		log.Errorf("failed to read postgres password from file \"%s\": %s", command.String("postgres-password-file"), err)
+		return err
+	}
 	databaseSettings := &db.Settings{
 		Host:         command.String("postgres-host"),
 		Port:         uint16(pgPort),
 		User:         command.String("postgres-user"),
-		Password:     command.String("postgres-password"),
+		Password:     postgresPassword,
 		DatabaseName: command.String("postgres-dbname"),
 		SSLMode:      command.String("postgres-sslmode"),
 	}


### PR DESCRIPTION
## Summary

Adds `--postgres-password-file` so the postgres password can be read from a file instead of appearing in process arguments.

- new `--postgres-password-file` flag; file contents (trailing newline trimmed) take precedence over `--postgres-password`
- `run.go` resolves the password via new `parsePostgresPassword` helper
- tests for inline fallback, file precedence + trimming, and missing file error

<!-- changelog:start -->
## Changelog

### Added

- `--postgres-password-file` flag to supply the postgres password from a file instead of a command-line argument.
<!-- changelog:end -->

## Test plan

- `go test ./cli/...`
- `make lint`
