### PR TITLE
fix(docker): set WORKDIR / so relative default paths resolve on distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM gcr.io/distroless/static-debian13:nonroot
 
+# the distroless nonroot base does not default the working directory to /, so
+# set it explicitly: the daemon's relative default paths (id_rsa.ca.pub,
+# id_rsa, id_rsa.pub, geoip.mmdb) resolve against the working directory, and
+# deployments mount those files at the container root.
+WORKDIR /
+
 COPY gatewaysshd /bin/gatewaysshd
 
 ENTRYPOINT ["/bin/gatewaysshd"]


### PR DESCRIPTION
## Summary

The distroless `nonroot` base image does not default the working directory to `/` like the old busybox image did, so the daemon's relative default file paths (`id_rsa.ca.pub`, `id_rsa`, `id_rsa.pub`, `geoip.mmdb`) no longer resolved against container-root mounts — startup crash-looped with `open id_rsa.ca.pub: no such file or directory`. Setting `WORKDIR /` restores the previous behavior.

<!-- changelog:start -->
### Fixed

- Set `WORKDIR /` in the Docker image so the daemon's relative default file paths resolve against container-root mounts (regression from the busybox→distroless switch)
<!-- changelog:end -->

## Test plan

- `docker inspect` confirms `WorkingDir=/`; running the image with a file mounted at `/id_rsa.ca.pub` now reads it (parse error) instead of "no such file"
- Verified on the production deployment (the compose absolute-path workaround can be dropped once this image ships)
