### PR TITLE
chore(ci): disable codecov project status check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+# the project status compares total coverage against the base commit with
+# zero tolerance, so it fails PRs that touch no code; keep only the patch
+# status, which checks coverage of the lines changed in the PR itself.
+coverage:
+  status:
+    project: off


### PR DESCRIPTION
> **Generated by AI, do not review or read yet.**

## Summary

Disable the `codecov/project` status check via `codecov.yml`. It compares total project coverage against the base with zero tolerance, so it fails PRs that touch no code (e.g. #10). The `codecov/patch` check is kept.

Config validated with `curl --data-binary @codecov.yml https://codecov.io/validate`.

<!-- changelog:start -->
## Changelog

No user-visible change — CI tweak, `skip-changelog` applied.
<!-- changelog:end -->

## Test plan

- codecov.io/validate accepts the config
- `codecov/project` status no longer reported on this PR
