### PR TITLE
chore: remove stale ci config leftovers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
 .git
 build
+gatewaysshd*
+tmp
+data
+id_rsa*

--- a/.gitignore
+++ b/.gitignore
@@ -1,31 +1,11 @@
-# Compiled Object files, Static and Dynamic libs (Shared Objects)
-*.o
-*.a
-*.so
-
-# Folders
-_obj
-_test
-
-# Architecture specific extensions/prefixes
-*.[568vq]
-[568vq].out
-
-*.cgo1.go
-*.cgo2.c
-_cgo_defun.c
-_cgo_gotypes.go
-_cgo_export.*
-
-_testmain.go
-
+# Build output
+/build
+/gatewaysshd*
 *.exe
 *.test
 *.prof
 
-# Project specific
+# Local runtime data
 /tmp
 /data
 /id_rsa*
-/build
-/gatewaysshd

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: go
-
-go:
-  - tip
-


### PR DESCRIPTION
## Summary

Remove dead config left over from the pre-GitHub-Actions era and tighten the ignore files.

- Delete `.travis.yml` — CI moved to GitHub Actions long ago.
- Trim GOPATH-era patterns from `.gitignore`; widen `/gatewaysshd*` to cover cross-compiled binaries.
- `.dockerignore`: exclude local keys (`id_rsa*`), runtime data, and root binaries from the Docker build context.

## Test plan

- `make check lint test` — no code changes; `go mod tidy` verified clean.