### PR TITLE
feat(gateway): add listOnlineUsers command and report nodeId per user

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -100,7 +100,7 @@ func (self *authenticator) authenticate(meta ssh.ConnMetadata, publicKey ssh.Pub
 		model.Location = location
 		model.NodeID = self.settings.NodeID
 		// mark online immediately; the gateway heartbeat keeps it fresh
-		model.OnlineAt = time.Now()
+		model.OnlineAt = time.Now().In(time.Local)
 		return nil
 	})
 	if err != nil {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -98,9 +98,13 @@ func (self *authenticator) authenticate(meta ssh.ConnMetadata, publicKey ssh.Pub
 	user, err := self.database.PutUser(context.Background(), meta.User(), func(model *db.User) error {
 		model.IP = ip.String()
 		model.Location = location
-		model.NodeID = self.settings.NodeID
-		// mark online immediately; the gateway heartbeat keeps it fresh
-		model.OnlineAt = time.Now().In(time.Local)
+		// presence is only recorded for logins that will be accepted, a
+		// disabled user is rejected right below and must not appear online
+		if !model.Disabled {
+			model.NodeID = self.settings.NodeID
+			// mark online immediately; the gateway heartbeat keeps it fresh
+			model.OnlineAt = time.Now().In(time.Local)
+		}
 		return nil
 	})
 	if err != nil {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net"
 	"net/netip"
+	"time"
 
 	logging "github.com/op/go-logging"
 	geoip2 "github.com/oschwald/geoip2-golang/v2"
@@ -98,6 +99,8 @@ func (self *authenticator) authenticate(meta ssh.ConnMetadata, publicKey ssh.Pub
 		model.IP = ip.String()
 		model.Location = location
 		model.NodeID = self.settings.NodeID
+		// mark online immediately; the gateway heartbeat keeps it fresh
+		model.OnlineAt = time.Now()
 		return nil
 	})
 	if err != nil {

--- a/cli/http_test.go
+++ b/cli/http_test.go
@@ -25,6 +25,10 @@ func (self *fakeGateway) ListUsers(context.Context) (interface{}, error) {
 	return map[string]interface{}{"users": []string{"alice"}}, nil
 }
 
+func (self *fakeGateway) ListOnlineUsers(context.Context) (interface{}, error) {
+	return map[string]interface{}{"users": []string{"alice"}}, nil
+}
+
 func (self *fakeGateway) GetUser(ctx context.Context, userId string) (interface{}, error) {
 	user, ok := self.users[userId]
 	if !ok {

--- a/db/db.go
+++ b/db/db.go
@@ -30,7 +30,7 @@ type Database interface {
 	Close() error
 
 	ListUsers(context.Context) ([]*User, error)
-	ListUsersByIDs(context.Context, []string) ([]*User, error)
+	GetUsers(context.Context, []string) ([]*User, error)
 	GetUser(context.Context, string) (*User, error)
 	PutUser(context.Context, string, func(*User) error) (*User, error)
 

--- a/db/db.go
+++ b/db/db.go
@@ -30,6 +30,7 @@ type Database interface {
 	Close() error
 
 	ListUsers(context.Context) ([]*User, error)
+	ListUsersByIDs(context.Context, []string) ([]*User, error)
 	GetUser(context.Context, string) (*User, error)
 	PutUser(context.Context, string, func(*User) error) (*User, error)
 

--- a/db/db.go
+++ b/db/db.go
@@ -31,7 +31,8 @@ type Database interface {
 
 	ListUsers(context.Context) ([]*User, error)
 	ListOnlineUsers(context.Context, time.Time) ([]*User, error)
-	MarkUsersOnline(context.Context, []string, string, time.Time) error
+	MarkUsersOnline(context.Context, []string, string, time.Duration) error
+	ClearUserNodeID(context.Context, string, string) error
 	GetUser(context.Context, string) (*User, error)
 	PutUser(context.Context, string, func(*User) error) (*User, error)
 

--- a/db/db.go
+++ b/db/db.go
@@ -30,7 +30,8 @@ type Database interface {
 	Close() error
 
 	ListUsers(context.Context) ([]*User, error)
-	GetUsers(context.Context, []string) ([]*User, error)
+	ListOnlineUsers(context.Context, time.Time) ([]*User, error)
+	MarkUsersOnline(context.Context, []string, time.Time) error
 	GetUser(context.Context, string) (*User, error)
 	PutUser(context.Context, string, func(*User) error) (*User, error)
 

--- a/db/db.go
+++ b/db/db.go
@@ -31,7 +31,7 @@ type Database interface {
 
 	ListUsers(context.Context) ([]*User, error)
 	ListOnlineUsers(context.Context, time.Time) ([]*User, error)
-	MarkUsersOnline(context.Context, []string, time.Time) error
+	MarkUsersOnline(context.Context, []string, string, time.Time) error
 	GetUser(context.Context, string) (*User, error)
 	PutUser(context.Context, string, func(*User) error) (*User, error)
 

--- a/db/migrations/0006_add_user_online_at.reverse.sql
+++ b/db/migrations/0006_add_user_online_at.reverse.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" DROP COLUMN "online_at";

--- a/db/migrations/0006_add_user_online_at.sql
+++ b/db/migrations/0006_add_user_online_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "online_at" timestamp with time zone;

--- a/db/models.go
+++ b/db/models.go
@@ -89,7 +89,11 @@ type User struct {
 	// the node the user last connected to, used for mesh tunneling
 	NodeID string `json:"nodeId,omitempty"`
 
-	// whether the user is online, not saved in database
+	// the last time the user was seen connected on any node; refreshed on a
+	// heartbeat while connected, so a fresh value means online mesh-wide
+	OnlineAt time.Time `json:"onlineAt,omitempty"`
+
+	// whether the user is online, derived from OnlineAt, not saved in database
 	Online bool `json:"online,omitempty" gorm:"-"`
 
 	// current connections, not saved in database

--- a/db/models.go
+++ b/db/models.go
@@ -119,10 +119,12 @@ type Node struct {
 	// dialing peers to verify the remote host
 	HostPublicKey string `json:"hostPublicKey,omitempty"`
 
-	// whether the node is online
+	// whether the node is online; cleared on clean shutdown, but a crashed
+	// node leaves it set, so liveness also requires a fresh OnlineAt
 	Online bool `json:"online,omitempty"`
 
-	// when the online status last changed
+	// the last online heartbeat, refreshed while the node is running, so a
+	// stale value marks a node that went away without marking itself offline
 	OnlineAt time.Time `json:"onlineAt,omitempty"`
 }
 

--- a/db/users.go
+++ b/db/users.go
@@ -20,6 +20,7 @@ var userListColumns = []string{
 	"administrator",
 	"disabled",
 	"node_id",
+	"online_at",
 }
 
 func (self *database) ListUsers(ctx context.Context) ([]*User, error) {
@@ -40,17 +41,14 @@ func (self *database) ListUsers(ctx context.Context) ([]*User, error) {
 	return results, nil
 }
 
-// GetUsers returns only the users with the given ids, filtered in sql, so
-// callers that already know the subset (e.g. currently-online users) do not
-// load the whole table.
-func (self *database) GetUsers(ctx context.Context, ids []string) ([]*User, error) {
-	if len(ids) == 0 {
-		return nil, nil
-	}
+// ListOnlineUsers returns the users whose online_at is newer than since,
+// filtered in sql. Online status is mesh-wide: any node refreshing a user's
+// online_at (see MarkUsersOnline) makes it visible from every node.
+func (self *database) ListOnlineUsers(ctx context.Context, since time.Time) ([]*User, error) {
 	var results []*User
 	if err := self.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var models []User
-		if err := tx.Select(userListColumns).Where("id IN ?", ids).Find(&models).Error; err != nil {
+		if err := tx.Select(userListColumns).Where("online_at > ?", since).Find(&models).Error; err != nil {
 			return err
 		}
 		results = make([]*User, 0, len(models))
@@ -62,6 +60,15 @@ func (self *database) GetUsers(ctx context.Context, ids []string) ([]*User, erro
 		return nil, err
 	}
 	return results, nil
+}
+
+// MarkUsersOnline refreshes online_at for the given users, called on a
+// heartbeat by the node they are connected to.
+func (self *database) MarkUsersOnline(ctx context.Context, ids []string, at time.Time) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	return self.db.WithContext(ctx).Model(&User{}).Where("id IN ?", ids).Update("online_at", at).Error
 }
 
 func (self *database) GetUser(ctx context.Context, userId string) (*User, error) {

--- a/db/users.go
+++ b/db/users.go
@@ -40,10 +40,10 @@ func (self *database) ListUsers(ctx context.Context) ([]*User, error) {
 	return results, nil
 }
 
-// ListUsersByIDs returns only the users with the given ids, filtered in sql, so
+// GetUsers returns only the users with the given ids, filtered in sql, so
 // callers that already know the subset (e.g. currently-online users) do not
 // load the whole table.
-func (self *database) ListUsersByIDs(ctx context.Context, ids []string) ([]*User, error) {
+func (self *database) GetUsers(ctx context.Context, ids []string) ([]*User, error) {
 	if len(ids) == 0 {
 		return nil, nil
 	}

--- a/db/users.go
+++ b/db/users.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // userListColumns are the columns returned by the user listing queries; the
@@ -23,11 +24,13 @@ var userListColumns = []string{
 	"online_at",
 }
 
-func (self *database) ListUsers(ctx context.Context) ([]*User, error) {
+// listUsers returns the users matching the optional conditions, selecting
+// only userListColumns.
+func (self *database) listUsers(ctx context.Context, conditions ...interface{}) ([]*User, error) {
 	var results []*User
 	if err := self.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var models []User
-		if err := tx.Select(userListColumns).Find(&models).Error; err != nil {
+		if err := tx.Select(userListColumns).Find(&models, conditions...).Error; err != nil {
 			return err
 		}
 		results = make([]*User, 0, len(models))
@@ -39,41 +42,51 @@ func (self *database) ListUsers(ctx context.Context) ([]*User, error) {
 		return nil, err
 	}
 	return results, nil
+}
+
+func (self *database) ListUsers(ctx context.Context) ([]*User, error) {
+	return self.listUsers(ctx)
 }
 
 // ListOnlineUsers returns the users whose online_at is newer than since,
 // filtered in sql. Online status is mesh-wide: any node refreshing a user's
 // online_at (see MarkUsersOnline) makes it visible from every node.
 func (self *database) ListOnlineUsers(ctx context.Context, since time.Time) ([]*User, error) {
-	var results []*User
-	if err := self.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var models []User
-		if err := tx.Select(userListColumns).Where("online_at > ?", since).Find(&models).Error; err != nil {
-			return err
-		}
-		results = make([]*User, 0, len(models))
-		for index := range models {
-			results = append(results, &models[index])
-		}
-		return nil
-	}); err != nil {
-		return nil, err
-	}
-	return results, nil
+	return self.listUsers(ctx, "online_at > ?", since)
 }
 
-// MarkUsersOnline refreshes online_at and node_id for the given users, called
-// on a heartbeat by the node they are connected to. Refreshing node_id keeps
-// it pointing at a node the user is currently on, self-healing the stale value
-// left behind when a user leaves the node it last authenticated to.
-func (self *database) MarkUsersOnline(ctx context.Context, ids []string, nodeId string, at time.Time) error {
-	if len(ids) == 0 {
+// MarkUsersOnline refreshes online_at for the given users, called on a
+// heartbeat by a node they are connected to. node_id is only adopted when the
+// user's current node is gone (unset, or its own heartbeat is older than
+// nodeStaleAfter): concurrent heartbeats from several nodes then leave a
+// multi-node user's node_id stable instead of fighting over it, while a node
+// that crashed or released the user still gets replaced.
+func (self *database) MarkUsersOnline(ctx context.Context, userIds []string, nodeId string, nodeStaleAfter time.Duration) error {
+	if len(userIds) == 0 {
 		return nil
 	}
-	return self.db.WithContext(ctx).Model(&User{}).Where("id IN ?", ids).Updates(map[string]interface{}{
-		"online_at": at,
-		"node_id":   nodeId,
-	}).Error
+	now := time.Now().In(time.Local)
+	return self.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&User{}).Where("id IN ?", userIds).Update("online_at", now).Error; err != nil {
+			return err
+		}
+		if nodeId == "" {
+			return nil // this node is not in the mesh, nothing to adopt
+		}
+		liveNodes := tx.Model(&Node{}).Select("id").Where("online AND online_at > ?", now.Add(-nodeStaleAfter))
+		return tx.Model(&User{}).
+			Where("id IN ? AND (node_id IS NULL OR node_id = '' OR node_id NOT IN (?))", userIds, liveNodes).
+			Updates(map[string]interface{}{"node_id": nodeId, "modified_at": now}).Error
+	})
+}
+
+// ClearUserNodeID clears the user's node_id if it still points at the given
+// node, called when the user's last connection to that node closes so that a
+// node the user is still connected to can adopt them on its next heartbeat.
+func (self *database) ClearUserNodeID(ctx context.Context, userId string, nodeId string) error {
+	return self.db.WithContext(ctx).Model(&User{}).
+		Where("id = ? AND node_id = ?", userId, nodeId).
+		Updates(map[string]interface{}{"node_id": "", "modified_at": time.Now().In(time.Local)}).Error
 }
 
 func (self *database) GetUser(ctx context.Context, userId string) (*User, error) {
@@ -99,7 +112,9 @@ func (self *database) PutUser(ctx context.Context, userId string, modifier func(
 	if err := self.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var create bool
 		var model User
-		if err := tx.Where("id = ?", userId).First(&model).Error; err != nil {
+		// lock the row for the read-modify-write, otherwise the Save below
+		// silently reverts a concurrent heartbeat's online_at/node_id update
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("id = ?", userId).First(&model).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				create = true
 			} else {

--- a/db/users.go
+++ b/db/users.go
@@ -21,6 +21,7 @@ func (self *database) ListUsers(ctx context.Context) ([]*User, error) {
 			"location",
 			"administrator",
 			"disabled",
+			"node_id",
 		}).Find(&models).Error; err != nil {
 			return err
 		}

--- a/db/users.go
+++ b/db/users.go
@@ -8,21 +8,49 @@ import (
 	"gorm.io/gorm"
 )
 
+// userListColumns are the columns returned by the user listing queries; the
+// heavy status/screenshot columns are intentionally omitted.
+var userListColumns = []string{
+	"id",
+	"created_at",
+	"modified_at",
+	"comment",
+	"ip",
+	"location",
+	"administrator",
+	"disabled",
+	"node_id",
+}
+
 func (self *database) ListUsers(ctx context.Context) ([]*User, error) {
 	var results []*User
 	if err := self.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var models []User
-		if err := tx.Select([]string{
-			"id",
-			"created_at",
-			"modified_at",
-			"comment",
-			"ip",
-			"location",
-			"administrator",
-			"disabled",
-			"node_id",
-		}).Find(&models).Error; err != nil {
+		if err := tx.Select(userListColumns).Find(&models).Error; err != nil {
+			return err
+		}
+		results = make([]*User, 0, len(models))
+		for index := range models {
+			results = append(results, &models[index])
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+// ListUsersByIDs returns only the users with the given ids, filtered in sql, so
+// callers that already know the subset (e.g. currently-online users) do not
+// load the whole table.
+func (self *database) ListUsersByIDs(ctx context.Context, ids []string) ([]*User, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var results []*User
+	if err := self.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var models []User
+		if err := tx.Select(userListColumns).Where("id IN ?", ids).Find(&models).Error; err != nil {
 			return err
 		}
 		results = make([]*User, 0, len(models))

--- a/db/users.go
+++ b/db/users.go
@@ -62,13 +62,18 @@ func (self *database) ListOnlineUsers(ctx context.Context, since time.Time) ([]*
 	return results, nil
 }
 
-// MarkUsersOnline refreshes online_at for the given users, called on a
-// heartbeat by the node they are connected to.
-func (self *database) MarkUsersOnline(ctx context.Context, ids []string, at time.Time) error {
+// MarkUsersOnline refreshes online_at and node_id for the given users, called
+// on a heartbeat by the node they are connected to. Refreshing node_id keeps
+// it pointing at a node the user is currently on, self-healing the stale value
+// left behind when a user leaves the node it last authenticated to.
+func (self *database) MarkUsersOnline(ctx context.Context, ids []string, nodeId string, at time.Time) error {
 	if len(ids) == 0 {
 		return nil
 	}
-	return self.db.WithContext(ctx).Model(&User{}).Where("id IN ?", ids).Update("online_at", at).Error
+	return self.db.WithContext(ctx).Model(&User{}).Where("id IN ?", ids).Updates(map[string]interface{}{
+		"online_at": at,
+		"node_id":   nodeId,
+	}).Error
 }
 
 func (self *database) GetUser(ctx context.Context, userId string) (*User, error) {

--- a/db/users_integration_test.go
+++ b/db/users_integration_test.go
@@ -2,6 +2,7 @@ package db_test
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 
@@ -163,48 +164,96 @@ func TestMarkUsersOnlineAndListOnlineUsers(t *testing.T) {
 	database, release := dbtest.AcquireDatabase(t)
 	defer release()
 
-	for _, name := range []string{"alice", "bob", "carol"} {
+	// a live node and a dead one, for the node_id adoption rule
+	seedNode := func(nodeId string, onlineAt time.Time) {
+		if _, err := database.PutNode(t.Context(), nodeId, func(node *db.Node) error {
+			node.Online = true
+			node.OnlineAt = onlineAt
+			return nil
+		}); err != nil {
+			t.Fatalf("failed to seed node %s: %s", nodeId, err)
+		}
+	}
+	seedNode("node-live", time.Now())
+	seedNode("node-dead", time.Now().Add(-time.Hour))
+
+	// alice sits on a live node, bob never comes online, carol's node died,
+	// dave never had a node
+	for name, nodeId := range map[string]string{"alice": "node-live", "bob": "node-live", "carol": "node-dead", "dave": ""} {
 		if _, err := database.PutUser(t.Context(), name, func(user *db.User) error {
-			user.NodeID = "node-x"
+			user.NodeID = nodeId
 			return nil
 		}); err != nil {
 			t.Fatalf("failed to create user %s: %s", name, err)
 		}
 	}
 
-	now := time.Now()
-
 	// empty id set is a no-op
-	if err := database.MarkUsersOnline(t.Context(), nil, "node-y", now); err != nil {
+	if err := database.MarkUsersOnline(t.Context(), nil, "node-y", time.Minute); err != nil {
 		t.Fatalf("expected nil for empty ids, got %v", err)
 	}
 
-	// mark alice and carol online now on node-y, bob stays offline
-	if err := database.MarkUsersOnline(t.Context(), []string{"alice", "carol"}, "node-y", now); err != nil {
+	// node-y heartbeats alice, carol and dave; bob stays offline
+	if err := database.MarkUsersOnline(t.Context(), []string{"alice", "carol", "dave"}, "node-y", time.Minute); err != nil {
 		t.Fatalf("failed to mark users online: %s", err)
 	}
 
-	got, err := database.ListOnlineUsers(t.Context(), now.Add(-time.Minute))
+	users, err := database.ListOnlineUsers(t.Context(), time.Now().Add(-time.Minute))
 	if err != nil {
 		t.Fatalf("failed to list online users: %s", err)
 	}
-	seen := make(map[string]bool)
-	for _, user := range got {
-		seen[user.ID] = true
-		// node_id self-heals to the node that beat the heartbeat
-		if user.NodeID != "node-y" {
-			t.Fatalf("expected nodeId node-y for %s, got %q", user.ID, user.NodeID)
-		}
+	nodes := make(map[string]string)
+	for _, user := range users {
 		if user.OnlineAt.IsZero() {
 			t.Fatalf("expected onlineAt to be set for %s", user.ID)
 		}
+		nodes[user.ID] = user.NodeID
 	}
-	if len(got) != 2 || !seen["alice"] || !seen["carol"] || seen["bob"] {
-		t.Fatalf("unexpected online subset: %+v", seen)
+	// alice keeps her live node, carol and dave are adopted by node-y
+	want := map[string]string{"alice": "node-live", "carol": "node-y", "dave": "node-y"}
+	if !reflect.DeepEqual(nodes, want) {
+		t.Fatalf("unexpected online users: %+v, want %+v", nodes, want)
 	}
 
 	// a since threshold newer than the heartbeat filters everyone out
-	if got, err := database.ListOnlineUsers(t.Context(), now.Add(time.Minute)); err != nil || len(got) != 0 {
-		t.Fatalf("expected no online users past the threshold, got %+v err %v", got, err)
+	if users, err := database.ListOnlineUsers(t.Context(), time.Now().Add(time.Minute)); err != nil || len(users) != 0 {
+		t.Fatalf("expected no online users past the threshold, got %+v err %v", users, err)
+	}
+
+	// a node not in the mesh refreshes online_at but never touches node_id
+	if err := database.MarkUsersOnline(t.Context(), []string{"dave"}, "", time.Minute); err != nil {
+		t.Fatalf("failed to mark users online without a node: %s", err)
+	}
+	if user, err := database.GetUser(t.Context(), "dave"); err != nil || user.NodeID != "node-y" {
+		t.Fatalf("expected node_id to survive a non-mesh heartbeat, got %+v err %v", user, err)
+	}
+}
+
+func TestClearUserNodeID(t *testing.T) {
+	t.Parallel()
+	database, release := dbtest.AcquireDatabase(t)
+	defer release()
+
+	if _, err := database.PutUser(t.Context(), "alice", func(user *db.User) error {
+		user.NodeID = "node-a"
+		return nil
+	}); err != nil {
+		t.Fatalf("failed to create user: %s", err)
+	}
+
+	// clearing on behalf of another node is a no-op
+	if err := database.ClearUserNodeID(t.Context(), "alice", "node-b"); err != nil {
+		t.Fatalf("failed to clear node: %s", err)
+	}
+	if user, err := database.GetUser(t.Context(), "alice"); err != nil || user.NodeID != "node-a" {
+		t.Fatalf("expected node_id to be kept, got %+v err %v", user, err)
+	}
+
+	// clearing by the owning node releases the user
+	if err := database.ClearUserNodeID(t.Context(), "alice", "node-a"); err != nil {
+		t.Fatalf("failed to clear node: %s", err)
+	}
+	if user, err := database.GetUser(t.Context(), "alice"); err != nil || user.NodeID != "" {
+		t.Fatalf("expected node_id to be cleared, got %+v err %v", user, err)
 	}
 }

--- a/db/users_integration_test.go
+++ b/db/users_integration_test.go
@@ -157,3 +157,39 @@ func TestListUsersOmitsHeavyColumns(t *testing.T) {
 		}
 	}
 }
+
+func TestListUsersByIDs(t *testing.T) {
+	t.Parallel()
+	database, release := dbtest.AcquireDatabase(t)
+	defer release()
+
+	for _, name := range []string{"alice", "bob", "carol"} {
+		if _, err := database.PutUser(t.Context(), name, func(user *db.User) error {
+			user.NodeID = "node-x"
+			return nil
+		}); err != nil {
+			t.Fatalf("failed to create user %s: %s", name, err)
+		}
+	}
+
+	// empty id set returns nothing without touching the table
+	if got, err := database.ListUsersByIDs(t.Context(), nil); err != nil || got != nil {
+		t.Fatalf("expected nil for empty ids, got %+v err %v", got, err)
+	}
+
+	// only the requested (existing) ids come back, with node_id populated
+	got, err := database.ListUsersByIDs(t.Context(), []string{"alice", "carol", "missing"})
+	if err != nil {
+		t.Fatalf("failed to list by ids: %s", err)
+	}
+	seen := make(map[string]bool)
+	for _, user := range got {
+		seen[user.ID] = true
+		if user.NodeID != "node-x" {
+			t.Fatalf("expected nodeId node-x for %s, got %q", user.ID, user.NodeID)
+		}
+	}
+	if len(got) != 2 || !seen["alice"] || !seen["carol"] || seen["bob"] {
+		t.Fatalf("unexpected subset: %+v", seen)
+	}
+}

--- a/db/users_integration_test.go
+++ b/db/users_integration_test.go
@@ -175,12 +175,12 @@ func TestMarkUsersOnlineAndListOnlineUsers(t *testing.T) {
 	now := time.Now()
 
 	// empty id set is a no-op
-	if err := database.MarkUsersOnline(t.Context(), nil, now); err != nil {
+	if err := database.MarkUsersOnline(t.Context(), nil, "node-y", now); err != nil {
 		t.Fatalf("expected nil for empty ids, got %v", err)
 	}
 
-	// mark alice and carol online now, bob stays offline
-	if err := database.MarkUsersOnline(t.Context(), []string{"alice", "carol"}, now); err != nil {
+	// mark alice and carol online now on node-y, bob stays offline
+	if err := database.MarkUsersOnline(t.Context(), []string{"alice", "carol"}, "node-y", now); err != nil {
 		t.Fatalf("failed to mark users online: %s", err)
 	}
 
@@ -191,8 +191,9 @@ func TestMarkUsersOnlineAndListOnlineUsers(t *testing.T) {
 	seen := make(map[string]bool)
 	for _, user := range got {
 		seen[user.ID] = true
-		if user.NodeID != "node-x" {
-			t.Fatalf("expected nodeId node-x for %s, got %q", user.ID, user.NodeID)
+		// node_id self-heals to the node that beat the heartbeat
+		if user.NodeID != "node-y" {
+			t.Fatalf("expected nodeId node-y for %s, got %q", user.ID, user.NodeID)
 		}
 		if user.OnlineAt.IsZero() {
 			t.Fatalf("expected onlineAt to be set for %s", user.ID)

--- a/db/users_integration_test.go
+++ b/db/users_integration_test.go
@@ -158,7 +158,7 @@ func TestListUsersOmitsHeavyColumns(t *testing.T) {
 	}
 }
 
-func TestGetUsers(t *testing.T) {
+func TestMarkUsersOnlineAndListOnlineUsers(t *testing.T) {
 	t.Parallel()
 	database, release := dbtest.AcquireDatabase(t)
 	defer release()
@@ -172,15 +172,21 @@ func TestGetUsers(t *testing.T) {
 		}
 	}
 
-	// empty id set returns nothing without touching the table
-	if got, err := database.GetUsers(t.Context(), nil); err != nil || got != nil {
-		t.Fatalf("expected nil for empty ids, got %+v err %v", got, err)
+	now := time.Now()
+
+	// empty id set is a no-op
+	if err := database.MarkUsersOnline(t.Context(), nil, now); err != nil {
+		t.Fatalf("expected nil for empty ids, got %v", err)
 	}
 
-	// only the requested (existing) ids come back, with node_id populated
-	got, err := database.GetUsers(t.Context(), []string{"alice", "carol", "missing"})
+	// mark alice and carol online now, bob stays offline
+	if err := database.MarkUsersOnline(t.Context(), []string{"alice", "carol"}, now); err != nil {
+		t.Fatalf("failed to mark users online: %s", err)
+	}
+
+	got, err := database.ListOnlineUsers(t.Context(), now.Add(-time.Minute))
 	if err != nil {
-		t.Fatalf("failed to list by ids: %s", err)
+		t.Fatalf("failed to list online users: %s", err)
 	}
 	seen := make(map[string]bool)
 	for _, user := range got {
@@ -188,8 +194,16 @@ func TestGetUsers(t *testing.T) {
 		if user.NodeID != "node-x" {
 			t.Fatalf("expected nodeId node-x for %s, got %q", user.ID, user.NodeID)
 		}
+		if user.OnlineAt.IsZero() {
+			t.Fatalf("expected onlineAt to be set for %s", user.ID)
+		}
 	}
 	if len(got) != 2 || !seen["alice"] || !seen["carol"] || seen["bob"] {
-		t.Fatalf("unexpected subset: %+v", seen)
+		t.Fatalf("unexpected online subset: %+v", seen)
+	}
+
+	// a since threshold newer than the heartbeat filters everyone out
+	if got, err := database.ListOnlineUsers(t.Context(), now.Add(time.Minute)); err != nil || len(got) != 0 {
+		t.Fatalf("expected no online users past the threshold, got %+v err %v", got, err)
 	}
 }

--- a/db/users_integration_test.go
+++ b/db/users_integration_test.go
@@ -158,7 +158,7 @@ func TestListUsersOmitsHeavyColumns(t *testing.T) {
 	}
 }
 
-func TestListUsersByIDs(t *testing.T) {
+func TestGetUsers(t *testing.T) {
 	t.Parallel()
 	database, release := dbtest.AcquireDatabase(t)
 	defer release()
@@ -173,12 +173,12 @@ func TestListUsersByIDs(t *testing.T) {
 	}
 
 	// empty id set returns nothing without touching the table
-	if got, err := database.ListUsersByIDs(t.Context(), nil); err != nil || got != nil {
+	if got, err := database.GetUsers(t.Context(), nil); err != nil || got != nil {
 		t.Fatalf("expected nil for empty ids, got %+v err %v", got, err)
 	}
 
 	// only the requested (existing) ids come back, with node_id populated
-	got, err := database.ListUsersByIDs(t.Context(), []string{"alice", "carol", "missing"})
+	got, err := database.GetUsers(t.Context(), []string{"alice", "carol", "missing"})
 	if err != nil {
 		t.Fatalf("failed to list by ids: %s", err)
 	}

--- a/gateway/connection.go
+++ b/gateway/connection.go
@@ -95,6 +95,7 @@ func handleConnection(gateway *gateway, conn *ssh.ServerConn, channels <-chan ss
 		defer self.waitGroup.Done()
 		defer func() {
 			self.gateway.deleteConnection(self)
+			self.gateway.releaseUserNode(self.user)
 			if err := self.conn.Close(); err != nil {
 				log.Warningf("%s: failed to close connection: %s", self, err)
 			}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -378,7 +378,7 @@ func (self *gateway) runOnlineHeartbeat(ctx context.Context) {
 			if len(ids) == 0 {
 				continue
 			}
-			if err := self.database.MarkUsersOnline(ctx, ids, self.settings.NodeID, time.Now()); err != nil {
+			if err := self.database.MarkUsersOnline(ctx, ids, self.settings.NodeID, time.Now().In(time.Local)); err != nil {
 				log.Warningf("failed to refresh online users: %s", err)
 			}
 		}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -344,9 +344,9 @@ func isOnline(user *db.User) bool {
 	return !user.OnlineAt.IsZero() && time.Since(user.OnlineAt) < onlineStaleThreshold
 }
 
-// connectedUserIDs returns the distinct users currently connected to this node.
+// connectedUserIds returns the distinct users currently connected to this node.
 // peer connections carry no user and are excluded.
-func (self *gateway) connectedUserIDs() []string {
+func (self *gateway) connectedUserIds() []string {
 	self.lock.Lock()
 	defer self.lock.Unlock()
 
@@ -374,11 +374,11 @@ func (self *gateway) runOnlineHeartbeat(ctx context.Context) {
 		case <-self.done:
 			return
 		case <-time.After(onlineHeartbeatInterval):
-			ids := self.connectedUserIDs()
+			ids := self.connectedUserIds()
 			if len(ids) == 0 {
 				continue
 			}
-			if err := self.database.MarkUsersOnline(ctx, ids, time.Now()); err != nil {
+			if err := self.database.MarkUsersOnline(ctx, ids, self.settings.NodeID, time.Now()); err != nil {
 				log.Warningf("failed to refresh online users: %s", err)
 			}
 		}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -322,28 +322,43 @@ func (self *gateway) gatherStatus(user string) map[string]interface{} {
 }
 
 func (self *gateway) ListUsers(ctx context.Context) (interface{}, error) {
+	return self.listUsers(ctx, false)
+}
+
+func (self *gateway) ListOnlineUsers(ctx context.Context) (interface{}, error) {
+	return self.listUsers(ctx, true)
+}
+
+// listUsers returns the users from the database annotated with their online
+// status; when onlineOnly is set, offline users are omitted.
+func (self *gateway) listUsers(ctx context.Context, onlineOnly bool) (interface{}, error) {
 	users, err := self.database.ListUsers(ctx)
 	if err != nil {
 		return nil, err
 	}
+	filtered := make([]*db.User, 0, len(users))
 	func() {
 		self.lock.Lock()
 		defer self.lock.Unlock()
+		online := make(map[string]bool, len(self.connectionsList))
+		for _, connection := range self.connectionsList {
+			if connection.user != "" {
+				online[connection.user] = true
+			}
+		}
 		for _, user := range users {
 			user.Status = nil
-			user.Online = false
-			for _, connection := range self.connectionsList {
-				if connection.user == user.ID {
-					user.Online = true
-					break
-				}
+			user.Online = online[user.ID]
+			if onlineOnly && !user.Online {
+				continue
 			}
+			filtered = append(filtered, user)
 		}
 	}()
 	return map[string]interface{}{
-		"users": users,
+		"users": filtered,
 		"meta": map[string]interface{}{
-			"totalCount": len(users),
+			"totalCount": len(filtered),
 		},
 	}, nil
 }

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -321,44 +321,59 @@ func (self *gateway) gatherStatus(user string) map[string]interface{} {
 	}
 }
 
+// onlineUsers returns the set of distinct user ids that currently have a
+// connection. peer connections carry no user and are excluded.
+func (self *gateway) onlineUsers() map[string]struct{} {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+
+	online := make(map[string]struct{}, len(self.connectionsList))
+	for _, connection := range self.connectionsList {
+		if connection.user != "" {
+			online[connection.user] = struct{}{}
+		}
+	}
+	return online
+}
+
 func (self *gateway) ListUsers(ctx context.Context) (interface{}, error) {
-	return self.listUsers(ctx, false)
-}
-
-func (self *gateway) ListOnlineUsers(ctx context.Context) (interface{}, error) {
-	return self.listUsers(ctx, true)
-}
-
-// listUsers returns the users from the database annotated with their online
-// status; when onlineOnly is set, offline users are omitted.
-func (self *gateway) listUsers(ctx context.Context, onlineOnly bool) (interface{}, error) {
 	users, err := self.database.ListUsers(ctx)
 	if err != nil {
 		return nil, err
 	}
-	filtered := make([]*db.User, 0, len(users))
-	func() {
-		self.lock.Lock()
-		defer self.lock.Unlock()
-		online := make(map[string]bool, len(self.connectionsList))
-		for _, connection := range self.connectionsList {
-			if connection.user != "" {
-				online[connection.user] = true
-			}
-		}
-		for _, user := range users {
-			user.Status = nil
-			user.Online = online[user.ID]
-			if onlineOnly && !user.Online {
-				continue
-			}
-			filtered = append(filtered, user)
-		}
-	}()
+	online := self.onlineUsers()
+	for _, user := range users {
+		user.Status = nil
+		_, user.Online = online[user.ID]
+	}
 	return map[string]interface{}{
-		"users": filtered,
+		"users": users,
 		"meta": map[string]interface{}{
-			"totalCount": len(filtered),
+			"totalCount": len(users),
+		},
+	}, nil
+}
+
+func (self *gateway) ListOnlineUsers(ctx context.Context) (interface{}, error) {
+	// the online users are a known, small subset, so query only their rows
+	// instead of loading and filtering the whole table
+	online := self.onlineUsers()
+	ids := make([]string, 0, len(online))
+	for id := range online {
+		ids = append(ids, id)
+	}
+	users, err := self.database.ListUsersByIDs(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	for _, user := range users {
+		user.Status = nil
+		user.Online = true
+	}
+	return map[string]interface{}{
+		"users": users,
+		"meta": map[string]interface{}{
+			"totalCount": len(users),
 		},
 	}, nil
 }

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -17,6 +17,16 @@ import (
 
 var log = logging.MustGetLogger("gateway")
 
+const (
+	// how often each node refreshes online_at for its connected users
+	onlineHeartbeatInterval = 30 * time.Second
+
+	// how long after the last heartbeat a user still counts as online; must be
+	// larger than onlineHeartbeatInterval so a user stays online between beats,
+	// and bounds how long a crashed node keeps its users appearing online
+	onlineStaleThreshold = 90 * time.Second
+)
+
 type Settings struct {
 	// version string
 	Version string
@@ -99,6 +109,12 @@ func Open(database db.Database, sshConfig *ssh.ServerConfig, settings *Settings)
 			self.runPeers(context.Background())
 		}()
 	}
+	self.waitGroup.Add(1)
+	go func() {
+		defer deferutil.Recover()
+		defer self.waitGroup.Done()
+		self.runOnlineHeartbeat(context.Background())
+	}()
 	return self, nil
 }
 
@@ -321,19 +337,52 @@ func (self *gateway) gatherStatus(user string) map[string]interface{} {
 	}
 }
 
-// onlineUsers returns the set of distinct user ids that currently have a
-// connection. peer connections carry no user and are excluded.
-func (self *gateway) onlineUsers() map[string]struct{} {
+// isOnline reports whether the user's online_at is fresh enough to count as
+// online. online_at is refreshed on a heartbeat by whichever node the user is
+// connected to, so this is mesh-wide.
+func isOnline(user *db.User) bool {
+	return !user.OnlineAt.IsZero() && time.Since(user.OnlineAt) < onlineStaleThreshold
+}
+
+// connectedUserIDs returns the distinct users currently connected to this node.
+// peer connections carry no user and are excluded.
+func (self *gateway) connectedUserIDs() []string {
 	self.lock.Lock()
 	defer self.lock.Unlock()
 
-	online := make(map[string]struct{}, len(self.connectionsList))
+	seen := make(map[string]struct{}, len(self.connectionsList))
+	ids := make([]string, 0, len(self.connectionsList))
 	for _, connection := range self.connectionsList {
-		if connection.user != "" {
-			online[connection.user] = struct{}{}
+		if connection.user == "" {
+			continue
+		}
+		if _, ok := seen[connection.user]; ok {
+			continue
+		}
+		seen[connection.user] = struct{}{}
+		ids = append(ids, connection.user)
+	}
+	return ids
+}
+
+// runOnlineHeartbeat periodically refreshes online_at for the users connected
+// to this node, so their online status is visible mesh-wide and ages out on
+// its own if this node stops beating.
+func (self *gateway) runOnlineHeartbeat(ctx context.Context) {
+	for {
+		select {
+		case <-self.done:
+			return
+		case <-time.After(onlineHeartbeatInterval):
+			ids := self.connectedUserIDs()
+			if len(ids) == 0 {
+				continue
+			}
+			if err := self.database.MarkUsersOnline(ctx, ids, time.Now()); err != nil {
+				log.Warningf("failed to refresh online users: %s", err)
+			}
 		}
 	}
-	return online
 }
 
 func (self *gateway) ListUsers(ctx context.Context) (interface{}, error) {
@@ -341,10 +390,9 @@ func (self *gateway) ListUsers(ctx context.Context) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	online := self.onlineUsers()
 	for _, user := range users {
 		user.Status = nil
-		_, user.Online = online[user.ID]
+		user.Online = isOnline(user)
 	}
 	return map[string]interface{}{
 		"users": users,
@@ -355,14 +403,9 @@ func (self *gateway) ListUsers(ctx context.Context) (interface{}, error) {
 }
 
 func (self *gateway) ListOnlineUsers(ctx context.Context) (interface{}, error) {
-	// the online users are a known, small subset, so query only their rows
-	// instead of loading and filtering the whole table
-	online := self.onlineUsers()
-	ids := make([]string, 0, len(online))
-	for id := range online {
-		ids = append(ids, id)
-	}
-	users, err := self.database.GetUsers(ctx, ids)
+	// online status is mesh-wide: query the users whose online_at is fresh,
+	// which includes users connected to other nodes
+	users, err := self.database.ListOnlineUsers(ctx, time.Now().Add(-onlineStaleThreshold))
 	if err != nil {
 		return nil, err
 	}
@@ -399,7 +442,8 @@ func (self *gateway) GetUser(ctx context.Context, userId string) (interface{}, e
 		}
 	}()
 
-	user.Online = len(connections) > 0
+	// online if connected here or seen recently on any node in the mesh
+	user.Online = len(connections) > 0 || isOnline(user)
 	user.Connections = connections
 
 	return map[string]interface{}{

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -68,6 +68,7 @@ type Gateway interface {
 	ScavengeConnections(time.Duration)
 
 	ListUsers(context.Context) (interface{}, error)
+	ListOnlineUsers(context.Context) (interface{}, error)
 	GetUser(context.Context, string) (interface{}, error)
 	GetUserScreenshot(context.Context, string) ([]byte, error)
 }
@@ -340,32 +341,34 @@ func (self *gateway) gatherStatus(user string) map[string]interface{} {
 	}
 }
 
+// isHeartbeatFresh reports whether an online heartbeat is recent enough to
+// count as online. Heartbeats are stamped with the writing node's clock, so
+// node clocks must be kept in sync (ntp) well within onlineStaleThreshold.
+func isHeartbeatFresh(onlineAt time.Time) bool {
+	return !onlineAt.IsZero() && time.Since(onlineAt) < onlineStaleThreshold
+}
+
 // isUserOnline reports whether the user's online_at is fresh enough to count
 // as online. online_at is refreshed on a heartbeat by whichever node the user
 // is connected to, so this is mesh-wide.
 func isUserOnline(user *db.User) bool {
-	return !user.OnlineAt.IsZero() && time.Since(user.OnlineAt) < onlineStaleThreshold
+	return isHeartbeatFresh(user.OnlineAt)
 }
 
-// connectedUserIds returns the distinct users currently connected to this node.
-// peer connections carry no user and are excluded.
+// connectedUserIds returns the distinct users currently connected to this
+// node. peer connections are indexed under an empty user and excluded.
 func (self *gateway) connectedUserIds() []string {
 	self.lock.Lock()
 	defer self.lock.Unlock()
 
-	seen := make(map[string]struct{}, len(self.connectionsList))
-	ids := make([]string, 0, len(self.connectionsList))
-	for _, connection := range self.connectionsList {
-		if connection.user == "" {
+	userIds := make([]string, 0, len(self.connectionsIndex))
+	for userId, connections := range self.connectionsIndex {
+		if userId == "" || len(connections) == 0 {
 			continue
 		}
-		if _, ok := seen[connection.user]; ok {
-			continue
-		}
-		seen[connection.user] = struct{}{}
-		ids = append(ids, connection.user)
+		userIds = append(userIds, userId)
 	}
-	return ids
+	return userIds
 }
 
 // runOnlineHeartbeat periodically refreshes online_at for the users connected
@@ -377,14 +380,47 @@ func (self *gateway) runOnlineHeartbeat(ctx context.Context) {
 		case <-self.done:
 			return
 		case <-time.After(onlineHeartbeatInterval):
-			ids := self.connectedUserIds()
-			if len(ids) == 0 {
+			userIds := self.connectedUserIds()
+			if len(userIds) == 0 {
 				continue
 			}
-			if err := self.database.MarkUsersOnline(ctx, ids, self.settings.NodeID, time.Now().In(time.Local)); err != nil {
+			// bound each beat so a wedged database cannot block this loop, and
+			// with it Close(), forever
+			beatContext, cancel := context.WithTimeout(ctx, onlineHeartbeatInterval)
+			err := self.database.MarkUsersOnline(beatContext, userIds, self.settings.NodeID, onlineStaleThreshold)
+			cancel()
+			if err != nil {
 				log.Warningf("failed to refresh online users: %s", err)
 			}
 		}
+	}
+}
+
+// releaseUserNode clears the user's node_id after their last connection to
+// this node closed, so a node the user is still connected to can adopt them
+// on its next heartbeat instead of mesh tunnels being routed here.
+func (self *gateway) releaseUserNode(userId string) {
+	if self.settings.NodeID == "" || userId == "" {
+		return
+	}
+	self.lock.Lock()
+	remaining := len(self.connectionsIndex[userId])
+	self.lock.Unlock()
+	if remaining > 0 {
+		return
+	}
+	if err := self.database.ClearUserNodeID(context.Background(), userId, self.settings.NodeID); err != nil {
+		log.Warningf("failed to release node of user %q: %s", userId, err)
+	}
+}
+
+// userListResponse is the common shape of the user listing commands
+func userListResponse(users []*db.User) interface{} {
+	return map[string]interface{}{
+		"users": users,
+		"meta": map[string]interface{}{
+			"totalCount": len(users),
+		},
 	}
 }
 
@@ -393,21 +429,24 @@ func (self *gateway) ListUsers(ctx context.Context) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+	// blend in this node's live connections, like GetUser, so local state
+	// stays accurate even when the heartbeat lags; users on other nodes are
+	// covered by the heartbeat
+	connected := make(map[string]struct{})
+	for _, userId := range self.connectedUserIds() {
+		connected[userId] = struct{}{}
+	}
 	for _, user := range users {
 		user.Status = nil
-		user.Online = isUserOnline(user)
+		_, local := connected[user.ID]
+		user.Online = local || isUserOnline(user)
 	}
-	return map[string]interface{}{
-		"users": users,
-		"meta": map[string]interface{}{
-			"totalCount": len(users),
-		},
-	}, nil
+	return userListResponse(users), nil
 }
 
 func (self *gateway) ListOnlineUsers(ctx context.Context) (interface{}, error) {
-	// online status is mesh-wide: query the users whose online_at is fresh,
-	// which includes users connected to other nodes
+	// online status is mesh-wide, derived purely from heartbeat freshness in
+	// sql, which includes users connected to other nodes
 	users, err := self.database.ListOnlineUsers(ctx, time.Now().Add(-onlineStaleThreshold))
 	if err != nil {
 		return nil, err
@@ -416,12 +455,7 @@ func (self *gateway) ListOnlineUsers(ctx context.Context) (interface{}, error) {
 		user.Status = nil
 		user.Online = true
 	}
-	return map[string]interface{}{
-		"users": users,
-		"meta": map[string]interface{}{
-			"totalCount": len(users),
-		},
-	}, nil
+	return userListResponse(users), nil
 }
 
 func (self *gateway) GetUser(ctx context.Context, userId string) (interface{}, error) {

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -21,9 +21,10 @@ const (
 	// how often each node refreshes online_at for its connected users
 	onlineHeartbeatInterval = 30 * time.Second
 
-	// how long after the last heartbeat a user still counts as online; must be
-	// larger than onlineHeartbeatInterval so a user stays online between beats,
-	// and bounds how long a crashed node keeps its users appearing online
+	// how long after the last heartbeat a user or node still counts as online;
+	// must be comfortably larger than the heartbeat intervals (onlineHeartbeatInterval
+	// for users, PeerDiscoveryInterval for nodes), and bounds how long a crashed
+	// node keeps itself and its users appearing online
 	onlineStaleThreshold = 90 * time.Second
 )
 
@@ -51,7 +52,9 @@ type Settings struct {
 	// refuses postgres tunnels
 	PostgresAddress string
 
-	// how often to look for new peer nodes, defaults to 15 seconds
+	// how often to look for new peer nodes and refresh this node's online
+	// heartbeat, defaults to 15 seconds; must stay well below
+	// onlineStaleThreshold or other nodes will consider this node dead
 	PeerDiscoveryInterval time.Duration
 }
 
@@ -99,7 +102,7 @@ func Open(database db.Database, sshConfig *ssh.ServerConfig, settings *Settings)
 		done:             make(chan struct{}),
 	}
 	if settings.NodeID != "" {
-		if err := self.registerNode(context.Background(), true, true); err != nil {
+		if err := self.registerNode(context.Background(), true); err != nil {
 			return nil, err
 		}
 		self.waitGroup.Add(1)
@@ -135,7 +138,7 @@ func (self *gateway) Close() {
 	self.waitGroup.Wait()
 
 	// mark this node as offline in the database
-	if err := self.registerNode(context.Background(), false, false); err != nil {
+	if err := self.registerNode(context.Background(), false); err != nil {
 		log.Warningf("failed to mark node as offline: %s", err)
 	}
 }
@@ -337,10 +340,10 @@ func (self *gateway) gatherStatus(user string) map[string]interface{} {
 	}
 }
 
-// isOnline reports whether the user's online_at is fresh enough to count as
-// online. online_at is refreshed on a heartbeat by whichever node the user is
-// connected to, so this is mesh-wide.
-func isOnline(user *db.User) bool {
+// isUserOnline reports whether the user's online_at is fresh enough to count
+// as online. online_at is refreshed on a heartbeat by whichever node the user
+// is connected to, so this is mesh-wide.
+func isUserOnline(user *db.User) bool {
 	return !user.OnlineAt.IsZero() && time.Since(user.OnlineAt) < onlineStaleThreshold
 }
 
@@ -392,7 +395,7 @@ func (self *gateway) ListUsers(ctx context.Context) (interface{}, error) {
 	}
 	for _, user := range users {
 		user.Status = nil
-		user.Online = isOnline(user)
+		user.Online = isUserOnline(user)
 	}
 	return map[string]interface{}{
 		"users": users,
@@ -443,7 +446,7 @@ func (self *gateway) GetUser(ctx context.Context, userId string) (interface{}, e
 	}()
 
 	// online if connected here or seen recently on any node in the mesh
-	user.Online = len(connections) > 0 || isOnline(user)
+	user.Online = len(connections) > 0 || isUserOnline(user)
 	user.Connections = connections
 
 	return map[string]interface{}{

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -362,7 +362,7 @@ func (self *gateway) ListOnlineUsers(ctx context.Context) (interface{}, error) {
 	for id := range online {
 		ids = append(ids, id)
 	}
-	users, err := self.database.ListUsersByIDs(ctx, ids)
+	users, err := self.database.GetUsers(ctx, ids)
 	if err != nil {
 		return nil, err
 	}

--- a/gateway/mesh_integration_test.go
+++ b/gateway/mesh_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"io"
 	"net"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -409,6 +410,9 @@ func TestGatewayNodeRegistration(t *testing.T) {
 	if node == nil || !node.Online || node.Address != address || node.HostPublicKey == "" {
 		t.Fatalf("unexpected node registration: %+v", node)
 	}
+	if time.Since(node.OnlineAt) > time.Minute {
+		t.Fatalf("expected a fresh online heartbeat, got %s", node.OnlineAt)
+	}
 
 	releaseNode()
 
@@ -418,6 +422,75 @@ func TestGatewayNodeRegistration(t *testing.T) {
 	}
 	if node == nil || node.Online {
 		t.Fatalf("expected node to be offline after close, got %+v", node)
+	}
+}
+
+// TestGatewayDiscoverySkipsCrashedNodes proves a node whose row still says
+// online but whose heartbeat went stale is not dialed: a crashed node cannot
+// mark itself offline, so peers must age it out instead of redialing forever.
+func TestGatewayDiscoverySkipsCrashedNodes(t *testing.T) {
+	t.Parallel()
+	database, release := dbtest.AcquireDatabase(t)
+	defer release()
+
+	// a listener that counts connection attempts and closes them right away
+	countingListener := func() (string, *atomic.Int32, func()) {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("failed to listen: %s", err)
+		}
+		var count atomic.Int32
+		go func() {
+			defer deferutil.Recover()
+			for {
+				socket, err := listener.Accept()
+				if err != nil {
+					return
+				}
+				count.Add(1)
+				_ = socket.Close()
+			}
+		}()
+		return listener.Addr().String(), &count, func() { _ = listener.Close() }
+	}
+	freshAddress, freshCount, closeFresh := countingListener()
+	defer closeFresh()
+	crashedAddress, crashedCount, closeCrashed := countingListener()
+	defer closeCrashed()
+
+	// seed one node with a fresh heartbeat and one whose heartbeat went stale
+	seedNode := func(nodeId, address string, onlineAt time.Time) {
+		hostPublicKey := string(ssh.MarshalAuthorizedKey(newTestSigner(t).PublicKey()))
+		if _, err := database.PutNode(t.Context(), nodeId, func(node *db.Node) error {
+			node.Address = address
+			node.HostPublicKey = hostPublicKey
+			node.Online = true
+			node.OnlineAt = onlineAt
+			return nil
+		}); err != nil {
+			t.Fatalf("failed to seed node %s: %s", nodeId, err)
+		}
+	}
+	seedNode("node-fresh", freshAddress, time.Now())
+	seedNode("node-crashed", crashedAddress, time.Now().Add(-5*time.Minute))
+
+	peerCaSigner := newTestSigner(t)
+	userCaSigner := newTestSigner(t)
+	_, _, releaseNode := startTestNode(t, database, userCaSigner, peerCaSigner, "node-a", "")
+	defer releaseNode()
+
+	// wait until the fresh node has been dialed a few times, proving several
+	// discovery cycles have processed both seeded rows
+	deadline := time.Now().Add(10 * time.Second)
+	for freshCount.Load() < 3 {
+		if time.Now().After(deadline) {
+			t.Fatalf("fresh node was only dialed %d times", freshCount.Load())
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	if count := crashedCount.Load(); count != 0 {
+		t.Fatalf("crashed node was dialed %d times", count)
 	}
 }
 

--- a/gateway/online_test.go
+++ b/gateway/online_test.go
@@ -1,0 +1,46 @@
+package gateway
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ziyan/gatewaysshd/db"
+)
+
+func TestIsUserOnline(t *testing.T) {
+	testCases := []struct {
+		name     string
+		onlineAt time.Time
+		want     bool
+	}{
+		{"never seen", time.Time{}, false},
+		{"fresh heartbeat", time.Now(), true},
+		{"stale heartbeat", time.Now().Add(-onlineStaleThreshold - time.Second), false},
+	}
+	for _, testCase := range testCases {
+		got := isUserOnline(&db.User{OnlineAt: testCase.onlineAt})
+		if got != testCase.want {
+			t.Fatalf("isUserOnline(%s) = %v, want %v", testCase.name, got, testCase.want)
+		}
+	}
+}
+
+func TestIsNodeOnline(t *testing.T) {
+	testCases := []struct {
+		name     string
+		online   bool
+		onlineAt time.Time
+		want     bool
+	}{
+		{"online and fresh", true, time.Now(), true},
+		{"crashed, row still online but heartbeat stale", true, time.Now().Add(-onlineStaleThreshold - time.Second), false},
+		{"online but never beat", true, time.Time{}, false},
+		{"cleanly shut down", false, time.Now(), false},
+	}
+	for _, testCase := range testCases {
+		got := isNodeOnline(&db.Node{Online: testCase.online, OnlineAt: testCase.onlineAt})
+		if got != testCase.want {
+			t.Fatalf("isNodeOnline(%s) = %v, want %v", testCase.name, got, testCase.want)
+		}
+	}
+}

--- a/gateway/peer.go
+++ b/gateway/peer.go
@@ -64,10 +64,10 @@ func (self *peer) close() {
 	})
 }
 
-// register this node in the database so other nodes can discover it. forceTime
-// stamps OnlineAt unconditionally, used at startup so a restart after an
-// unclean shutdown (row still Online=true) still records the new online time.
-func (self *gateway) registerNode(ctx context.Context, online, forceTime bool) error {
+// register this node in the database so other nodes can discover it. OnlineAt
+// is refreshed on every heartbeat while online, so peers can tell a live node
+// from one that crashed while its row still says Online=true.
+func (self *gateway) registerNode(ctx context.Context, online bool) error {
 	if self.settings.NodeID == "" {
 		return nil
 	}
@@ -79,17 +79,20 @@ func (self *gateway) registerNode(ctx context.Context, online, forceTime bool) e
 	if _, err := self.database.PutNode(ctx, self.settings.NodeID, func(node *db.Node) error {
 		node.Address = self.settings.NodeAddress
 		node.HostPublicKey = hostPublicKey
-		// OnlineAt marks when the online state last changed, so only stamp it on
-		// a transition (or when forced at startup) instead of every heartbeat
-		if forceTime || node.Online != online || node.OnlineAt.IsZero() {
-			node.OnlineAt = now
-		}
 		node.Online = online
+		node.OnlineAt = now
 		return nil
 	}); err != nil {
 		return err
 	}
 	return nil
+}
+
+// isNodeOnline reports whether a node registration is live: marked online and
+// heartbeat fresh. A crashed node cannot mark itself offline, so a stale
+// heartbeat means dead, keeping peers from redialing it forever.
+func isNodeOnline(node *db.Node) bool {
+	return node.Online && !node.OnlineAt.IsZero() && time.Since(node.OnlineAt) < onlineStaleThreshold
 }
 
 // discover other online nodes from the database and connect to them
@@ -103,7 +106,7 @@ func (self *gateway) discoverPeers(ctx context.Context) error {
 	}
 
 	for _, node := range nodes {
-		if !node.Online || node.Address == "" || node.ID == self.settings.NodeID {
+		if !isNodeOnline(node) || node.Address == "" || node.ID == self.settings.NodeID {
 			continue // cannot connect
 		}
 		if self.getPeer(node.ID) != nil {
@@ -182,7 +185,7 @@ func (self *gateway) runPeers(ctx context.Context) {
 		case <-self.done:
 			return
 		case <-time.After(interval):
-			if err := self.registerNode(ctx, true, false); err != nil {
+			if err := self.registerNode(ctx, true); err != nil {
 				log.Warningf("failed to register node: %s", err)
 			}
 			if err := self.discoverPeers(ctx); err != nil {

--- a/gateway/peer.go
+++ b/gateway/peer.go
@@ -92,7 +92,7 @@ func (self *gateway) registerNode(ctx context.Context, online bool) error {
 // heartbeat fresh. A crashed node cannot mark itself offline, so a stale
 // heartbeat means dead, keeping peers from redialing it forever.
 func isNodeOnline(node *db.Node) bool {
-	return node.Online && !node.OnlineAt.IsZero() && time.Since(node.OnlineAt) < onlineStaleThreshold
+	return node.Online && isHeartbeatFresh(node.OnlineAt)
 }
 
 // discover other online nodes from the database and connect to them
@@ -176,6 +176,14 @@ func (self *gateway) runPeers(ctx context.Context) {
 	interval := self.settings.PeerDiscoveryInterval
 	if interval <= 0 {
 		interval = 15 * time.Second
+	}
+	// the discovery interval doubles as the node online heartbeat, so it needs
+	// margin for a missed beat before other nodes consider this node dead
+	if interval > onlineStaleThreshold/3 {
+		log.Warningf(
+			"peer discovery interval %s leaves no heartbeat margin within the %s online threshold, other nodes may consider this node dead",
+			interval, onlineStaleThreshold,
+		)
 	}
 	if err := self.discoverPeers(ctx); err != nil {
 		log.Warningf("failed to discover peers: %s", err)

--- a/gateway/service.go
+++ b/gateway/service.go
@@ -148,6 +148,8 @@ func (self *service) handleCommand(command []string) error {
 		return self.status(command[1])
 	case len(command) == 1 && command[0] == "listUsers":
 		return self.listUsers()
+	case len(command) == 1 && command[0] == "listOnlineUsers":
+		return self.listOnlineUsers()
 	case len(command) == 2 && command[0] == "getUser":
 		return self.getUser(command[1])
 	}
@@ -172,6 +174,7 @@ func (self *service) help() error {
 		content = append(content, []string{
 			"    status [username] - show gateway status, optionally filter by username",
 			"    listUsers - list all users in database",
+			"    listOnlineUsers - list users that are currently online",
 			"    getUser <username> - get details about a user from database",
 			"",
 		}...)
@@ -281,6 +284,14 @@ func (self *service) reportScreenshot() error {
 
 func (self *service) listUsers() error {
 	output, err := self.connection.gateway.ListUsers(context.Background())
+	if err != nil {
+		return err
+	}
+	return self.marshal(output)
+}
+
+func (self *service) listOnlineUsers() error {
+	output, err := self.connection.gateway.ListOnlineUsers(context.Background())
 	if err != nil {
 		return err
 	}

--- a/gateway/service_integration_test.go
+++ b/gateway/service_integration_test.go
@@ -342,3 +342,49 @@ func TestGatewayListOnlineUsers(t *testing.T) {
 		}
 	}
 }
+
+// TestGatewayListOnlineUsersMeshWide proves online status is mesh-wide: a user
+// connected only to another node still shows up as online, with that node's id.
+func TestGatewayListOnlineUsersMeshWide(t *testing.T) {
+	t.Parallel()
+	database, release := dbtest.AcquireDatabase(t)
+	defer release()
+
+	peerCaSigner := newTestSigner(t)
+	userCaSignerA := newTestSigner(t)
+	userCaSignerB := newTestSigner(t)
+
+	addressA, _, releaseA := startTestNode(t, database, userCaSignerA, peerCaSigner, "node-a", "")
+	defer releaseA()
+	addressB, _, releaseB := startTestNode(t, database, userCaSignerB, peerCaSigner, "node-b", "")
+	defer releaseB()
+
+	extensions := map[string]string{"permit-port-forwarding": ""}
+
+	// carol connects only to node b
+	carol := dialTestGateway(t, addressB, newCertSigner(t, userCaSignerB, "carol", extensions), "carol")
+	defer func() {
+		_ = carol.Close()
+	}()
+
+	// bob connects to node a and queries from there
+	bob := dialTestGateway(t, addressA, newCertSigner(t, userCaSignerA, "bob", extensions), "bob")
+	defer func() {
+		_ = bob.Close()
+	}()
+
+	var online userList
+	if err := json.Unmarshal([]byte(runCommand(t, bob, "listOnlineUsers")), &online); err != nil {
+		t.Fatalf("failed to parse listOnlineUsers output: %s", err)
+	}
+	nodes := make(map[string]string)
+	for _, user := range online.Users {
+		nodes[user.ID] = user.NodeID
+	}
+	if node, ok := nodes["carol"]; !ok || node != "node-b" {
+		t.Fatalf("expected carol online on node-b, got %+v", nodes)
+	}
+	if node, ok := nodes["bob"]; !ok || node != "node-a" {
+		t.Fatalf("expected bob online on node-a, got %+v", nodes)
+	}
+}

--- a/gateway/service_integration_test.go
+++ b/gateway/service_integration_test.go
@@ -11,7 +11,20 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/ziyan/gatewaysshd/db"
+	"github.com/ziyan/gatewaysshd/db/dbtest"
 )
+
+// userList is the shape of listUsers / listOnlineUsers output for assertions.
+type userList struct {
+	Users []struct {
+		ID     string `json:"id"`
+		Online bool   `json:"online"`
+		NodeID string `json:"nodeId"`
+	} `json:"users"`
+	Meta struct {
+		TotalCount int `json:"totalCount"`
+	} `json:"meta"`
+}
 
 func runCommand(t *testing.T, client *ssh.Client, command string) string {
 	t.Helper()
@@ -267,5 +280,65 @@ func TestGatewayKickUserRequiresAdministrator(t *testing.T) {
 	case <-done:
 	case <-time.After(10 * time.Second):
 		t.Fatal("expected victim connection to be closed")
+	}
+}
+
+// TestGatewayListOnlineUsers proves listOnlineUsers returns only currently
+// connected users and that each user record carries its nodeId.
+func TestGatewayListOnlineUsers(t *testing.T) {
+	t.Parallel()
+	database, release := dbtest.AcquireDatabase(t)
+	defer release()
+
+	peerCaSigner := newTestSigner(t)
+	userCaSigner := newTestSigner(t)
+	address, _, releaseNode := startTestNode(t, database, userCaSigner, peerCaSigner, "node-a", "")
+	defer releaseNode()
+
+	// a user that exists in the database but is not connected
+	if _, err := database.PutUser(t.Context(), "ghost", func(user *db.User) error {
+		return nil
+	}); err != nil {
+		t.Fatalf("failed to create offline user: %s", err)
+	}
+
+	// bob connects (online) and can run the listing commands
+	extensions := map[string]string{"permit-port-forwarding": ""}
+	bob := dialTestGateway(t, address, newCertSigner(t, userCaSigner, "bob", extensions), "bob")
+	defer func() {
+		_ = bob.Close()
+	}()
+
+	parse := func(command string) userList {
+		t.Helper()
+		var result userList
+		if err := json.Unmarshal([]byte(runCommand(t, bob, command)), &result); err != nil {
+			t.Fatalf("failed to parse %s output: %s", command, err)
+		}
+		return result
+	}
+
+	// listUsers includes both the online (bob) and offline (ghost) users
+	all := parse("listUsers")
+	if all.Meta.TotalCount != 2 {
+		t.Fatalf("expected listUsers totalCount 2, got %d", all.Meta.TotalCount)
+	}
+
+	// listOnlineUsers returns only bob, with online=true and nodeId set
+	online := parse("listOnlineUsers")
+	if online.Meta.TotalCount != 1 {
+		t.Fatalf("expected listOnlineUsers totalCount 1, got %d", online.Meta.TotalCount)
+	}
+	user := online.Users[0]
+	if user.ID != "bob" || !user.Online {
+		t.Fatalf("unexpected online user: %+v", user)
+	}
+	if user.NodeID != "node-a" {
+		t.Fatalf("expected nodeId node-a, got %q", user.NodeID)
+	}
+	for _, candidate := range online.Users {
+		if candidate.ID == "ghost" {
+			t.Fatal("listOnlineUsers included an offline user")
+		}
 	}
 }

--- a/gateway/service_integration_test.go
+++ b/gateway/service_integration_test.go
@@ -26,6 +26,16 @@ type userList struct {
 	} `json:"meta"`
 }
 
+// parseUserList runs a user listing command and parses its JSON output.
+func parseUserList(t *testing.T, client *ssh.Client, command string) userList {
+	t.Helper()
+	var result userList
+	if err := json.Unmarshal([]byte(runCommand(t, client, command)), &result); err != nil {
+		t.Fatalf("failed to parse %s output: %s", command, err)
+	}
+	return result
+}
+
 func runCommand(t *testing.T, client *ssh.Client, command string) string {
 	t.Helper()
 	session, err := client.NewSession()
@@ -309,23 +319,14 @@ func TestGatewayListOnlineUsers(t *testing.T) {
 		_ = bob.Close()
 	}()
 
-	parse := func(command string) userList {
-		t.Helper()
-		var result userList
-		if err := json.Unmarshal([]byte(runCommand(t, bob, command)), &result); err != nil {
-			t.Fatalf("failed to parse %s output: %s", command, err)
-		}
-		return result
-	}
-
 	// listUsers includes both the online (bob) and offline (ghost) users
-	all := parse("listUsers")
+	all := parseUserList(t, bob, "listUsers")
 	if all.Meta.TotalCount != 2 {
 		t.Fatalf("expected listUsers totalCount 2, got %d", all.Meta.TotalCount)
 	}
 
 	// listOnlineUsers returns only bob, with online=true and nodeId set
-	online := parse("listOnlineUsers")
+	online := parseUserList(t, bob, "listOnlineUsers")
 	if online.Meta.TotalCount != 1 {
 		t.Fatalf("expected listOnlineUsers totalCount 1, got %d", online.Meta.TotalCount)
 	}
@@ -373,10 +374,7 @@ func TestGatewayListOnlineUsersMeshWide(t *testing.T) {
 		_ = bob.Close()
 	}()
 
-	var online userList
-	if err := json.Unmarshal([]byte(runCommand(t, bob, "listOnlineUsers")), &online); err != nil {
-		t.Fatalf("failed to parse listOnlineUsers output: %s", err)
-	}
+	online := parseUserList(t, bob, "listOnlineUsers")
 	nodes := make(map[string]string)
 	for _, user := range online.Users {
 		nodes[user.ID] = user.NodeID
@@ -386,5 +384,50 @@ func TestGatewayListOnlineUsersMeshWide(t *testing.T) {
 	}
 	if node, ok := nodes["bob"]; !ok || node != "node-a" {
 		t.Fatalf("expected bob online on node-a, got %+v", nodes)
+	}
+}
+
+// TestGatewayReleasesUserNodeOnDisconnect proves the user's node_id is
+// released when their last connection to the node closes, so a node they are
+// still connected to can adopt them on its next heartbeat.
+func TestGatewayReleasesUserNodeOnDisconnect(t *testing.T) {
+	t.Parallel()
+	database, release := dbtest.AcquireDatabase(t)
+	defer release()
+
+	peerCaSigner := newTestSigner(t)
+	userCaSigner := newTestSigner(t)
+	address, _, releaseNode := startTestNode(t, database, userCaSigner, peerCaSigner, "node-a", "")
+	defer releaseNode()
+
+	extensions := map[string]string{"permit-port-forwarding": ""}
+	bob := dialTestGateway(t, address, newCertSigner(t, userCaSigner, "bob", extensions), "bob")
+	defer func() {
+		_ = bob.Close()
+	}()
+
+	user, err := database.GetUser(t.Context(), "bob")
+	if err != nil || user == nil || user.NodeID != "node-a" {
+		t.Fatalf("expected bob on node-a, got %+v err %v", user, err)
+	}
+
+	if err := bob.Close(); err != nil {
+		t.Fatalf("failed to close connection: %s", err)
+	}
+
+	// the connection teardown that releases node_id is asynchronous
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		user, err := database.GetUser(t.Context(), "bob")
+		if err != nil {
+			t.Fatalf("failed to get user: %s", err)
+		}
+		if user.NodeID == "" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected node_id to be released, still %q", user.NodeID)
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
 }

--- a/gateway/service_integration_test.go
+++ b/gateway/service_integration_test.go
@@ -312,17 +312,33 @@ func TestGatewayListOnlineUsers(t *testing.T) {
 		t.Fatalf("failed to create offline user: %s", err)
 	}
 
-	// bob connects (online) and can run the listing commands
+	// a disabled user whose rejected login attempt must not count as online
+	if _, err := database.PutUser(t.Context(), "mallory", func(user *db.User) error {
+		user.Disabled = true
+		return nil
+	}); err != nil {
+		t.Fatalf("failed to create disabled user: %s", err)
+	}
 	extensions := map[string]string{"permit-port-forwarding": ""}
+	if _, err := ssh.Dial("tcp", address, &ssh.ClientConfig{
+		User:            "mallory",
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(newCertSigner(t, userCaSigner, "mallory", extensions))},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
+		Timeout:         10 * time.Second,
+	}); err == nil {
+		t.Fatal("expected disabled user login to be rejected")
+	}
+
+	// bob connects (online) and can run the listing commands
 	bob := dialTestGateway(t, address, newCertSigner(t, userCaSigner, "bob", extensions), "bob")
 	defer func() {
 		_ = bob.Close()
 	}()
 
-	// listUsers includes both the online (bob) and offline (ghost) users
+	// listUsers includes the online (bob) and offline (ghost, mallory) users
 	all := parseUserList(t, bob, "listUsers")
-	if all.Meta.TotalCount != 2 {
-		t.Fatalf("expected listUsers totalCount 2, got %d", all.Meta.TotalCount)
+	if all.Meta.TotalCount != 3 {
+		t.Fatalf("expected listUsers totalCount 3, got %d", all.Meta.TotalCount)
 	}
 
 	// listOnlineUsers returns only bob, with online=true and nodeId set
@@ -338,8 +354,8 @@ func TestGatewayListOnlineUsers(t *testing.T) {
 		t.Fatalf("expected nodeId node-a, got %q", user.NodeID)
 	}
 	for _, candidate := range online.Users {
-		if candidate.ID == "ghost" {
-			t.Fatal("listOnlineUsers included an offline user")
+		if candidate.ID == "ghost" || candidate.ID == "mallory" {
+			t.Fatalf("listOnlineUsers included an offline user %s", candidate.ID)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Adds a `listOnlineUsers` gateway shell command, reports each user's `nodeId`
in the JSON output, and makes online status mesh-wide.

- `listOnlineUsers` returns online users (gated behind `permit-port-forwarding`,
  same as `listUsers`), with help text.
- Every user record carries `nodeId` in the JSON of `listUsers`,
  `listOnlineUsers`, and the HTTP `/api/user` endpoint.
- Online status is mesh-wide: a persisted `online_at` timestamp is refreshed on
  a 30s heartbeat by the node a user is connected to; a user is online when
  `online_at` is within 90s, so users connected to other nodes show as online
  and a crashed node's users age out on their own.
- Node liveness is heartbeat-based too: a crashed node (row stuck at
  `online=true`) ages out of peer discovery instead of being redialed forever.
- `node_id` stays stable for users connected to several nodes: heartbeats only
  adopt a user whose current node is gone, and a node releases `node_id` when
  the user's last connection to it closes.

<!-- changelog:start -->
### Added

- `listOnlineUsers` shell command that lists users currently online across the mesh
- Each user record now reports its `nodeId` in the JSON output

### Fixed

- Crashed nodes now age out of peer discovery instead of being redialed forever
- `nodeId` no longer goes stale when a user leaves one node but stays on another

### Changed

- Node liveness is now derived from a heartbeat; upgrade all mesh nodes together,
  old-binary nodes do not refresh their heartbeat and will be considered offline
<!-- changelog:end -->

## Test plan

- `TestGatewayListOnlineUsers` / `TestGatewayListOnlineUsersMeshWide` /
  `TestGatewayReleasesUserNodeOnDisconnect` (postgres-backed)
- `TestMarkUsersOnlineAndListOnlineUsers` (adoption rule), `TestClearUserNodeID`,
  `TestGatewayDiscoverySkipsCrashedNodes`, `TestIsUserOnline` / `TestIsNodeOnline`
- `make test` (postgres + `-race`), `make lint`, `make lint-mulint` all clean