### PR TITLE
perf(db): single-roundtrip hot paths and listLocalOnlineUsers

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"net"
 	"net/netip"
-	"time"
 
 	logging "github.com/op/go-logging"
 	geoip2 "github.com/oschwald/geoip2-golang/v2"
@@ -94,19 +93,11 @@ func (self *authenticator) authenticate(meta ssh.ConnMetadata, publicKey ssh.Pub
 	delete(permissions.Extensions, "peer")
 	delete(permissions.Extensions, "identity")
 
-	// update user in database
-	user, err := self.database.PutUser(context.Background(), meta.User(), func(model *db.User) error {
-		model.IP = ip.String()
-		model.Location = location
-		// presence is only recorded for logins that will be accepted, a
-		// disabled user is rejected right below and must not appear online
-		if !model.Disabled {
-			model.NodeID = self.settings.NodeID
-			// mark online immediately; the gateway heartbeat keeps it fresh
-			model.OnlineAt = time.Now().In(time.Local)
-		}
-		return nil
-	})
+	// update user in database, a single upsert so the authentication path
+	// costs one database roundtrip; presence (node_id, online_at) is only
+	// recorded for logins that will be accepted, a disabled user is rejected
+	// right below and must not appear online
+	user, err := self.database.UpsertUserOnConnect(context.Background(), meta.User(), ip.String(), location, self.settings.NodeID)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/http_test.go
+++ b/cli/http_test.go
@@ -29,6 +29,10 @@ func (self *fakeGateway) ListOnlineUsers(context.Context) (interface{}, error) {
 	return map[string]interface{}{"users": []string{"alice"}}, nil
 }
 
+func (self *fakeGateway) ListLocalOnlineUsers(context.Context) (interface{}, error) {
+	return map[string]interface{}{"users": []string{"alice"}}, nil
+}
+
 func (self *fakeGateway) GetUser(ctx context.Context, userId string) (interface{}, error) {
 	user, ok := self.users[userId]
 	if !ok {

--- a/db/db.go
+++ b/db/db.go
@@ -31,9 +31,14 @@ type Database interface {
 
 	ListUsers(context.Context) ([]*User, error)
 	ListOnlineUsers(context.Context, time.Time) ([]*User, error)
+	GetUsers(context.Context, []string) ([]*User, error)
 	MarkUsersOnline(context.Context, []string, string, time.Duration) error
 	ClearUserNodeID(context.Context, string, string) error
 	GetUser(context.Context, string) (*User, error)
+	GetUserNodeID(context.Context, string) (string, error)
+	UpsertUserOnConnect(context.Context, string, string, Location, string) (*User, error)
+	UpdateUserStatus(context.Context, string, Status) error
+	UpdateUserScreenshot(context.Context, string, []byte) error
 	PutUser(context.Context, string, func(*User) error) (*User, error)
 
 	ListNodes(context.Context) ([]*Node, error)

--- a/db/db.go
+++ b/db/db.go
@@ -36,6 +36,7 @@ type Database interface {
 	ClearUserNodeID(context.Context, string, string) error
 	GetUser(context.Context, string) (*User, error)
 	GetUserNodeID(context.Context, string) (string, error)
+	GetUserScreenshot(context.Context, string) ([]byte, error)
 	UpsertUserOnConnect(context.Context, string, string, Location, string) (*User, error)
 	UpdateUserStatus(context.Context, string, Status) error
 	UpdateUserScreenshot(context.Context, string, []byte) error

--- a/db/dbtest/dbtest.go
+++ b/db/dbtest/dbtest.go
@@ -112,6 +112,28 @@ func AcquireDatabase(test *testing.T) (db.Database, func()) {
 	return database, release
 }
 
+// ExecSQL runs a raw statement against the test database, for setting up row
+// states the public Database API cannot produce (e.g. legacy NULL columns).
+func ExecSQL(test *testing.T, settings *db.Settings, query string, arguments ...interface{}) {
+	test.Helper()
+	dsn := fmt.Sprintf(
+		"host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
+		settings.Host, settings.Port, settings.User, settings.Password, settings.DatabaseName,
+	)
+	database, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		test.Fatalf("failed to open test database for raw sql: %s", err)
+	}
+	defer func() {
+		if err := closeDatabase(database); err != nil {
+			test.Fatalf("failed to close test database: %s", err)
+		}
+	}()
+	if err := database.Exec(query, arguments...).Error; err != nil {
+		test.Fatalf("failed to execute %q: %s", query, err)
+	}
+}
+
 // AcquireDatabaseWithSettings is AcquireDatabase but also returns the
 // connection settings, so tests can open additional connections to the same
 // database (e.g. tunneled through a peer node).

--- a/db/users.go
+++ b/db/users.go
@@ -25,6 +25,10 @@ var userListColumns = []string{
 	"online_at",
 }
 
+// userDetailColumns adds the status blob for the single-user queries; only
+// the screenshot is left out, it is served by GetUserScreenshot alone.
+var userDetailColumns = append(append([]string{}, userListColumns...), "status")
+
 // listUsers returns the users matching the optional conditions, selecting
 // only userListColumns. No transaction wrapper: a single statement is atomic
 // on its own, and the extra BEGIN/COMMIT roundtrips are costly when the
@@ -105,13 +109,26 @@ func (self *database) ClearUserNodeID(ctx context.Context, userId string, nodeId
 
 func (self *database) GetUser(ctx context.Context, userId string) (*User, error) {
 	var model User
-	if err := self.db.WithContext(ctx).Where("id = ?", userId).First(&model).Error; err != nil {
+	if err := self.db.WithContext(ctx).Select(userDetailColumns).Where("id = ?", userId).First(&model).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, err
 	}
 	return &model, nil
+}
+
+// GetUserScreenshot fetches only the screenshot blob, nil when the user is
+// unknown or never reported one.
+func (self *database) GetUserScreenshot(ctx context.Context, userId string) ([]byte, error) {
+	var screenshots [][]byte
+	if err := self.db.WithContext(ctx).Model(&User{}).Where("id = ?", userId).Limit(1).Pluck("screenshot", &screenshots).Error; err != nil {
+		return nil, err
+	}
+	if len(screenshots) == 0 {
+		return nil, nil
+	}
+	return screenshots[0], nil
 }
 
 // GetUserNodeID returns the node the user last connected to, or empty when
@@ -134,7 +151,9 @@ func (self *database) GetUserNodeID(ctx context.Context, userId string) (string,
 // user on first connect and refreshes ip, location and presence (node_id,
 // online_at). Presence is kept unchanged for a disabled user, whose login is
 // rejected right after and must not appear online. A single statement keeps
-// the authentication path at one database roundtrip.
+// the authentication path at one database roundtrip; the returned user
+// reflects the stored row for all light columns (RETURNING), only the status
+// and screenshot blobs are intentionally not fetched.
 func (self *database) UpsertUserOnConnect(ctx context.Context, userId string, ip string, location Location, nodeId string) (*User, error) {
 	now := time.Now().In(time.Local)
 	model := User{
@@ -145,6 +164,10 @@ func (self *database) UpsertUserOnConnect(ctx context.Context, userId string, ip
 		Location:   location,
 		NodeID:     nodeId,
 		OnlineAt:   now,
+	}
+	returningColumns := make([]clause.Column, 0, len(userListColumns))
+	for _, column := range userListColumns {
+		returningColumns = append(returningColumns, clause.Column{Name: column})
 	}
 	if err := self.db.WithContext(ctx).Clauses(
 		clause.OnConflict{
@@ -157,29 +180,39 @@ func (self *database) UpsertUserOnConnect(ctx context.Context, userId string, ip
 				"online_at":   gorm.Expr(`CASE WHEN "user".disabled THEN "user".online_at ELSE excluded.online_at END`),
 			}),
 		},
-		clause.Returning{Columns: []clause.Column{{Name: "administrator"}, {Name: "disabled"}}},
+		clause.Returning{Columns: returningColumns},
 	).Create(&model).Error; err != nil {
 		return nil, err
 	}
 	return &model, nil
 }
 
-// UpdateUserStatus saves only the reported status, a single small statement
-// on the frequently-called reporting path.
-func (self *database) UpdateUserStatus(ctx context.Context, userId string, status Status) error {
-	return self.db.WithContext(ctx).Model(&User{}).Where("id = ?", userId).Updates(map[string]interface{}{
-		"status":      status,
+// updateUserColumn saves a single column of an existing user, one small
+// statement for the frequently-called reporting paths. A report for a user
+// row that vanished is an error instead of a silent no-op.
+func (self *database) updateUserColumn(ctx context.Context, userId string, column string, value interface{}) error {
+	result := self.db.WithContext(ctx).Model(&User{}).Where("id = ?", userId).Updates(map[string]interface{}{
+		column:        value,
 		"modified_at": time.Now().In(time.Local),
-	}).Error
+	})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
 }
 
-// UpdateUserScreenshot saves only the reported screenshot, a single statement
-// that does not drag the status blob along.
+// UpdateUserStatus saves only the reported status.
+func (self *database) UpdateUserStatus(ctx context.Context, userId string, status Status) error {
+	return self.updateUserColumn(ctx, userId, "status", status)
+}
+
+// UpdateUserScreenshot saves only the reported screenshot, without dragging
+// the status blob along.
 func (self *database) UpdateUserScreenshot(ctx context.Context, userId string, screenshot []byte) error {
-	return self.db.WithContext(ctx).Model(&User{}).Where("id = ?", userId).Updates(map[string]interface{}{
-		"screenshot":  screenshot,
-		"modified_at": time.Now().In(time.Local),
-	}).Error
+	return self.updateUserColumn(ctx, userId, "screenshot", screenshot)
 }
 
 func (self *database) PutUser(ctx context.Context, userId string, modifier func(*User) error) (*User, error) {

--- a/db/users.go
+++ b/db/users.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"time"
 
@@ -25,21 +26,17 @@ var userListColumns = []string{
 }
 
 // listUsers returns the users matching the optional conditions, selecting
-// only userListColumns.
+// only userListColumns. No transaction wrapper: a single statement is atomic
+// on its own, and the extra BEGIN/COMMIT roundtrips are costly when the
+// database is reached through a cross-region peer tunnel.
 func (self *database) listUsers(ctx context.Context, conditions ...interface{}) ([]*User, error) {
-	var results []*User
-	if err := self.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var models []User
-		if err := tx.Select(userListColumns).Find(&models, conditions...).Error; err != nil {
-			return err
-		}
-		results = make([]*User, 0, len(models))
-		for index := range models {
-			results = append(results, &models[index])
-		}
-		return nil
-	}); err != nil {
+	var models []User
+	if err := self.db.WithContext(ctx).Select(userListColumns).Find(&models, conditions...).Error; err != nil {
 		return nil, err
+	}
+	results := make([]*User, 0, len(models))
+	for index := range models {
+		results = append(results, &models[index])
 	}
 	return results, nil
 }
@@ -55,29 +52,46 @@ func (self *database) ListOnlineUsers(ctx context.Context, since time.Time) ([]*
 	return self.listUsers(ctx, "online_at > ?", since)
 }
 
+// GetUsers returns only the users with the given ids, filtered in sql, so
+// callers that already know the subset do not load the whole table.
+func (self *database) GetUsers(ctx context.Context, userIds []string) ([]*User, error) {
+	if len(userIds) == 0 {
+		return nil, nil
+	}
+	return self.listUsers(ctx, "id IN ?", userIds)
+}
+
+// userNodeGone matches a user whose recorded node is absent or has a stale
+// heartbeat, so the beating node may adopt them. Takes one parameter: the
+// time before which a node heartbeat counts as stale.
+const userNodeGone = `(node_id IS NULL OR node_id = '' OR node_id NOT IN (SELECT id FROM "node" WHERE online AND online_at > ?))`
+
 // MarkUsersOnline refreshes online_at for the given users, called on a
 // heartbeat by a node they are connected to. node_id is only adopted when the
 // user's current node is gone (unset, or its own heartbeat is older than
 // nodeStaleAfter): concurrent heartbeats from several nodes then leave a
 // multi-node user's node_id stable instead of fighting over it, while a node
-// that crashed or released the user still gets replaced.
+// that crashed or released the user still gets replaced. A single statement,
+// so the periodic heartbeat costs one roundtrip and holds no locks across
+// the cross-region tunnel.
 func (self *database) MarkUsersOnline(ctx context.Context, userIds []string, nodeId string, nodeStaleAfter time.Duration) error {
 	if len(userIds) == 0 {
 		return nil
 	}
 	now := time.Now().In(time.Local)
-	return self.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := tx.Model(&User{}).Where("id IN ?", userIds).Update("online_at", now).Error; err != nil {
-			return err
-		}
-		if nodeId == "" {
-			return nil // this node is not in the mesh, nothing to adopt
-		}
-		liveNodes := tx.Model(&Node{}).Select("id").Where("online AND online_at > ?", now.Add(-nodeStaleAfter))
-		return tx.Model(&User{}).
-			Where("id IN ? AND (node_id IS NULL OR node_id = '' OR node_id NOT IN (?))", userIds, liveNodes).
-			Updates(map[string]interface{}{"node_id": nodeId, "modified_at": now}).Error
-	})
+	if nodeId == "" {
+		// this node is not in the mesh, only refresh the heartbeat
+		return self.db.WithContext(ctx).Model(&User{}).Where("id IN ?", userIds).Update("online_at", now).Error
+	}
+	// every SET expression sees the old row, so both CASEs test the same state
+	staleBefore := now.Add(-nodeStaleAfter)
+	return self.db.WithContext(ctx).Exec(
+		`UPDATE "user" SET online_at = ?, `+
+			`modified_at = CASE WHEN `+userNodeGone+` THEN ? ELSE modified_at END, `+
+			`node_id = CASE WHEN `+userNodeGone+` THEN ? ELSE node_id END `+
+			`WHERE id IN ?`,
+		now, staleBefore, now, staleBefore, nodeId, userIds,
+	).Error
 }
 
 // ClearUserNodeID clears the user's node_id if it still points at the given
@@ -90,21 +104,82 @@ func (self *database) ClearUserNodeID(ctx context.Context, userId string, nodeId
 }
 
 func (self *database) GetUser(ctx context.Context, userId string) (*User, error) {
-	var result *User
-	if err := self.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var model User
-		if err := tx.Where("id = ?", userId).First(&model).Error; err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				return nil
-			}
-			return err
+	var model User
+	if err := self.db.WithContext(ctx).Where("id = ?", userId).First(&model).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
 		}
-		result = &model
-		return nil
-	}); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return &model, nil
+}
+
+// GetUserNodeID returns the node the user last connected to, or empty when
+// the user is unknown. It fetches a single column so the mesh tunnel routing
+// path costs one small roundtrip instead of pulling the whole row with its
+// status and screenshot blobs.
+func (self *database) GetUserNodeID(ctx context.Context, userId string) (string, error) {
+	var nodeId string
+	err := self.db.WithContext(ctx).Raw(`SELECT coalesce(node_id, '') FROM "user" WHERE id = ?`, userId).Row().Scan(&nodeId)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return nodeId, nil
+}
+
+// UpsertUserOnConnect records a login in a single statement: it creates the
+// user on first connect and refreshes ip, location and presence (node_id,
+// online_at). Presence is kept unchanged for a disabled user, whose login is
+// rejected right after and must not appear online. A single statement keeps
+// the authentication path at one database roundtrip.
+func (self *database) UpsertUserOnConnect(ctx context.Context, userId string, ip string, location Location, nodeId string) (*User, error) {
+	now := time.Now().In(time.Local)
+	model := User{
+		ID:         userId,
+		CreatedAt:  now,
+		ModifiedAt: now,
+		IP:         ip,
+		Location:   location,
+		NodeID:     nodeId,
+		OnlineAt:   now,
+	}
+	if err := self.db.WithContext(ctx).Clauses(
+		clause.OnConflict{
+			Columns: []clause.Column{{Name: "id"}},
+			DoUpdates: clause.Assignments(map[string]interface{}{
+				"modified_at": now,
+				"ip":          ip,
+				"location":    location,
+				"node_id":     gorm.Expr(`CASE WHEN "user".disabled THEN "user".node_id ELSE excluded.node_id END`),
+				"online_at":   gorm.Expr(`CASE WHEN "user".disabled THEN "user".online_at ELSE excluded.online_at END`),
+			}),
+		},
+		clause.Returning{Columns: []clause.Column{{Name: "administrator"}, {Name: "disabled"}}},
+	).Create(&model).Error; err != nil {
+		return nil, err
+	}
+	return &model, nil
+}
+
+// UpdateUserStatus saves only the reported status, a single small statement
+// on the frequently-called reporting path.
+func (self *database) UpdateUserStatus(ctx context.Context, userId string, status Status) error {
+	return self.db.WithContext(ctx).Model(&User{}).Where("id = ?", userId).Updates(map[string]interface{}{
+		"status":      status,
+		"modified_at": time.Now().In(time.Local),
+	}).Error
+}
+
+// UpdateUserScreenshot saves only the reported screenshot, a single statement
+// that does not drag the status blob along.
+func (self *database) UpdateUserScreenshot(ctx context.Context, userId string, screenshot []byte) error {
+	return self.db.WithContext(ctx).Model(&User{}).Where("id = ?", userId).Updates(map[string]interface{}{
+		"screenshot":  screenshot,
+		"modified_at": time.Now().In(time.Local),
+	}).Error
 }
 
 func (self *database) PutUser(ctx context.Context, userId string, modifier func(*User) error) (*User, error) {

--- a/db/users_integration_test.go
+++ b/db/users_integration_test.go
@@ -229,6 +229,163 @@ func TestMarkUsersOnlineAndListOnlineUsers(t *testing.T) {
 	}
 }
 
+func TestUpsertUserOnConnect(t *testing.T) {
+	t.Parallel()
+	database, release := dbtest.AcquireDatabase(t)
+	defer release()
+
+	location := db.Location{Country: "JP", City: "Tokyo"}
+
+	// first connect creates the user with presence
+	user, err := database.UpsertUserOnConnect(t.Context(), "alice", "203.0.113.7", location, "node-a")
+	if err != nil {
+		t.Fatalf("failed to upsert new user: %s", err)
+	}
+	if user.Administrator || user.Disabled {
+		t.Fatalf("expected fresh flags, got %+v", user)
+	}
+	created, err := database.GetUser(t.Context(), "alice")
+	if err != nil || created == nil {
+		t.Fatalf("failed to get created user: %+v err %v", created, err)
+	}
+	if created.IP != "203.0.113.7" || created.Location != location || created.NodeID != "node-a" || created.OnlineAt.IsZero() {
+		t.Fatalf("unexpected created user: %+v", created)
+	}
+
+	// reconnect on another node refreshes presence and reports existing flags
+	if _, err := database.PutUser(t.Context(), "alice", func(model *db.User) error {
+		model.Administrator = true
+		return nil
+	}); err != nil {
+		t.Fatalf("failed to promote user: %s", err)
+	}
+	user, err = database.UpsertUserOnConnect(t.Context(), "alice", "203.0.113.8", location, "node-b")
+	if err != nil {
+		t.Fatalf("failed to upsert existing user: %s", err)
+	}
+	if !user.Administrator {
+		t.Fatal("expected administrator flag to be returned")
+	}
+	updated, err := database.GetUser(t.Context(), "alice")
+	if err != nil {
+		t.Fatalf("failed to get updated user: %s", err)
+	}
+	if updated.IP != "203.0.113.8" || updated.NodeID != "node-b" {
+		t.Fatalf("expected refreshed presence, got %+v", updated)
+	}
+	if !updated.CreatedAt.Equal(created.CreatedAt) {
+		t.Fatalf("expected creation time to be preserved, got %s != %s", updated.CreatedAt, created.CreatedAt)
+	}
+
+	// a disabled user's rejected login refreshes ip but not presence
+	if _, err := database.PutUser(t.Context(), "mallory", func(model *db.User) error {
+		model.Disabled = true
+		return nil
+	}); err != nil {
+		t.Fatalf("failed to create disabled user: %s", err)
+	}
+	user, err = database.UpsertUserOnConnect(t.Context(), "mallory", "198.51.100.9", location, "node-a")
+	if err != nil {
+		t.Fatalf("failed to upsert disabled user: %s", err)
+	}
+	if !user.Disabled {
+		t.Fatal("expected disabled flag to be returned")
+	}
+	rejected, err := database.GetUser(t.Context(), "mallory")
+	if err != nil {
+		t.Fatalf("failed to get disabled user: %s", err)
+	}
+	if rejected.IP != "198.51.100.9" {
+		t.Fatalf("expected ip to be recorded for audit, got %q", rejected.IP)
+	}
+	if rejected.NodeID != "" || !rejected.OnlineAt.IsZero() {
+		t.Fatalf("expected no presence for disabled user, got %+v", rejected)
+	}
+}
+
+func TestUpdateUserStatusAndScreenshot(t *testing.T) {
+	t.Parallel()
+	database, release := dbtest.AcquireDatabase(t)
+	defer release()
+
+	if _, err := database.UpsertUserOnConnect(t.Context(), "alice", "203.0.113.7", db.Location{}, "node-a"); err != nil {
+		t.Fatalf("failed to create user: %s", err)
+	}
+
+	if err := database.UpdateUserStatus(t.Context(), "alice", db.Status(`{"healthy":true}`)); err != nil {
+		t.Fatalf("failed to update status: %s", err)
+	}
+	if err := database.UpdateUserScreenshot(t.Context(), "alice", []byte{0x89, 0x50}); err != nil {
+		t.Fatalf("failed to update screenshot: %s", err)
+	}
+
+	// both updates are targeted: they must not clobber each other or presence
+	user, err := database.GetUser(t.Context(), "alice")
+	if err != nil {
+		t.Fatalf("failed to get user: %s", err)
+	}
+	var status map[string]bool
+	if err := json.Unmarshal(user.Status, &status); err != nil || !status["healthy"] {
+		t.Fatalf("unexpected status %s: %v", user.Status, err)
+	}
+	if len(user.Screenshot) != 2 {
+		t.Fatalf("unexpected screenshot: %v", user.Screenshot)
+	}
+	if user.IP != "203.0.113.7" || user.NodeID != "node-a" || user.OnlineAt.IsZero() {
+		t.Fatalf("expected other fields untouched, got %+v", user)
+	}
+}
+
+func TestGetUserNodeID(t *testing.T) {
+	t.Parallel()
+	database, release := dbtest.AcquireDatabase(t)
+	defer release()
+
+	// unknown user reads as empty, same as a user without a node
+	if nodeId, err := database.GetUserNodeID(t.Context(), "missing"); err != nil || nodeId != "" {
+		t.Fatalf("expected empty node for missing user, got %q err %v", nodeId, err)
+	}
+
+	if _, err := database.UpsertUserOnConnect(t.Context(), "alice", "203.0.113.7", db.Location{}, "node-a"); err != nil {
+		t.Fatalf("failed to create user: %s", err)
+	}
+	if nodeId, err := database.GetUserNodeID(t.Context(), "alice"); err != nil || nodeId != "node-a" {
+		t.Fatalf("expected node-a, got %q err %v", nodeId, err)
+	}
+}
+
+func TestGetUsers(t *testing.T) {
+	t.Parallel()
+	database, release := dbtest.AcquireDatabase(t)
+	defer release()
+
+	for _, name := range []string{"alice", "bob", "carol"} {
+		if _, err := database.PutUser(t.Context(), name, func(user *db.User) error {
+			return nil
+		}); err != nil {
+			t.Fatalf("failed to create user %s: %s", name, err)
+		}
+	}
+
+	// empty id set returns nothing without touching the table
+	if users, err := database.GetUsers(t.Context(), nil); err != nil || users != nil {
+		t.Fatalf("expected nil for empty ids, got %+v err %v", users, err)
+	}
+
+	// only the requested (existing) ids come back
+	users, err := database.GetUsers(t.Context(), []string{"alice", "carol", "missing"})
+	if err != nil {
+		t.Fatalf("failed to get users: %s", err)
+	}
+	seen := make(map[string]bool)
+	for _, user := range users {
+		seen[user.ID] = true
+	}
+	if len(users) != 2 || !seen["alice"] || !seen["carol"] {
+		t.Fatalf("unexpected subset: %+v", seen)
+	}
+}
+
 func TestClearUserNodeID(t *testing.T) {
 	t.Parallel()
 	database, release := dbtest.AcquireDatabase(t)

--- a/db/users_integration_test.go
+++ b/db/users_integration_test.go
@@ -70,8 +70,12 @@ func TestPutUserCreatesAndGetUserRoundTrips(t *testing.T) {
 	if !status["healthy"] {
 		t.Fatalf("unexpected status: %s", user.Status)
 	}
-	if len(user.Screenshot) != 4 {
-		t.Fatalf("unexpected screenshot: %v", user.Screenshot)
+	// the screenshot blob is only served by the dedicated query
+	if len(user.Screenshot) != 0 {
+		t.Fatalf("expected screenshot to be omitted by GetUser, got %v", user.Screenshot)
+	}
+	if screenshot, err := database.GetUserScreenshot(t.Context(), "alice"); err != nil || len(screenshot) != 4 {
+		t.Fatalf("unexpected screenshot %v: %v", screenshot, err)
 	}
 }
 
@@ -266,6 +270,10 @@ func TestUpsertUserOnConnect(t *testing.T) {
 	if !user.Administrator {
 		t.Fatal("expected administrator flag to be returned")
 	}
+	// the returned user reflects the stored row, not the attempted values
+	if !user.CreatedAt.Equal(created.CreatedAt) {
+		t.Fatalf("expected returned creation time to be preserved, got %s != %s", user.CreatedAt, created.CreatedAt)
+	}
 	updated, err := database.GetUser(t.Context(), "alice")
 	if err != nil {
 		t.Fatalf("failed to get updated user: %s", err)
@@ -290,6 +298,10 @@ func TestUpsertUserOnConnect(t *testing.T) {
 	}
 	if !user.Disabled {
 		t.Fatal("expected disabled flag to be returned")
+	}
+	// the returned user reflects the stored row: no presence was recorded
+	if user.NodeID != "" || !user.OnlineAt.IsZero() {
+		t.Fatalf("expected returned user without presence, got %+v", user)
 	}
 	rejected, err := database.GetUser(t.Context(), "mallory")
 	if err != nil {
@@ -328,17 +340,22 @@ func TestUpdateUserStatusAndScreenshot(t *testing.T) {
 	if err := json.Unmarshal(user.Status, &status); err != nil || !status["healthy"] {
 		t.Fatalf("unexpected status %s: %v", user.Status, err)
 	}
-	if len(user.Screenshot) != 2 {
-		t.Fatalf("unexpected screenshot: %v", user.Screenshot)
+	if screenshot, err := database.GetUserScreenshot(t.Context(), "alice"); err != nil || len(screenshot) != 2 {
+		t.Fatalf("unexpected screenshot %v: %v", screenshot, err)
 	}
 	if user.IP != "203.0.113.7" || user.NodeID != "node-a" || user.OnlineAt.IsZero() {
 		t.Fatalf("expected other fields untouched, got %+v", user)
+	}
+
+	// a report for a user row that vanished is an error, not a silent no-op
+	if err := database.UpdateUserStatus(t.Context(), "missing", db.Status(`{}`)); err == nil {
+		t.Fatal("expected error for missing user")
 	}
 }
 
 func TestGetUserNodeID(t *testing.T) {
 	t.Parallel()
-	database, release := dbtest.AcquireDatabase(t)
+	database, settings, release := dbtest.AcquireDatabaseWithSettings(t)
 	defer release()
 
 	// unknown user reads as empty, same as a user without a node
@@ -351,6 +368,13 @@ func TestGetUserNodeID(t *testing.T) {
 	}
 	if nodeId, err := database.GetUserNodeID(t.Context(), "alice"); err != nil || nodeId != "node-a" {
 		t.Fatalf("expected node-a, got %q err %v", nodeId, err)
+	}
+
+	// rows from before the node_id migration hold NULL, which must read as
+	// empty instead of failing the scan
+	dbtest.ExecSQL(t, settings, `UPDATE "user" SET node_id = NULL WHERE id = ?`, "alice")
+	if nodeId, err := database.GetUserNodeID(t.Context(), "alice"); err != nil || nodeId != "" {
+		t.Fatalf("expected empty node for legacy NULL, got %q err %v", nodeId, err)
 	}
 }
 

--- a/gateway/connection.go
+++ b/gateway/connection.go
@@ -200,10 +200,9 @@ func (self *connection) getUsedAt() time.Time {
 // }
 
 func (self *connection) reportStatus(status json.RawMessage) error {
-	if _, err := self.gateway.database.PutUser(context.Background(), self.user, func(model *db.User) error {
-		model.Status = db.Status(status)
-		return nil
-	}); err != nil {
+	// targeted update, the frequent reporting path must not read and write
+	// back the whole row over the cross-region tunnel
+	if err := self.gateway.database.UpdateUserStatus(context.Background(), self.user, db.Status(status)); err != nil {
 		log.Errorf("%s: failed to save user in database: %s", self, err)
 		return err
 	}
@@ -211,10 +210,7 @@ func (self *connection) reportStatus(status json.RawMessage) error {
 }
 
 func (self *connection) reportScreenshot(screenshot []byte) error {
-	if _, err := self.gateway.database.PutUser(context.Background(), self.user, func(model *db.User) error {
-		model.Screenshot = screenshot
-		return nil
-	}); err != nil {
+	if err := self.gateway.database.UpdateUserScreenshot(context.Background(), self.user, screenshot); err != nil {
 		log.Errorf("%s: failed to save user in database: %s", self, err)
 		return err
 	}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -69,6 +69,7 @@ type Gateway interface {
 
 	ListUsers(context.Context) (interface{}, error)
 	ListOnlineUsers(context.Context) (interface{}, error)
+	ListLocalOnlineUsers(context.Context) (interface{}, error)
 	GetUser(context.Context, string) (interface{}, error)
 	GetUserScreenshot(context.Context, string) ([]byte, error)
 }
@@ -241,21 +242,21 @@ func (self *gateway) lookupRemotePeer(ctx context.Context, host string) *peer {
 		if user == "" {
 			continue
 		}
-		model, err := self.database.GetUser(ctx, user)
+		nodeId, err := self.database.GetUserNodeID(ctx, user)
 		if err != nil {
 			// a transient error on one candidate must not abort resolving the
 			// remaining, more-specific user suffixes
 			log.Warningf("failed to look up user %q for mesh tunneling: %s", user, err)
 			continue
 		}
-		if model == nil || model.NodeID == "" || model.NodeID == self.settings.NodeID {
+		if nodeId == "" || nodeId == self.settings.NodeID {
 			continue
 		}
-		if peer := self.getPeer(model.NodeID); peer != nil {
-			log.Debugf("lookup: found remote node for host %q: node = %s", host, model.NodeID)
+		if peer := self.getPeer(nodeId); peer != nil {
+			log.Debugf("lookup: found remote node for host %q: node = %s", host, nodeId)
 			return peer
 		}
-		log.Debugf("lookup: user %q is on node %s but no peer connection is available", user, model.NodeID)
+		log.Debugf("lookup: user %q is on node %s but no peer connection is available", user, nodeId)
 	}
 	return nil
 }
@@ -448,6 +449,20 @@ func (self *gateway) ListOnlineUsers(ctx context.Context) (interface{}, error) {
 	// online status is mesh-wide, derived purely from heartbeat freshness in
 	// sql, which includes users connected to other nodes
 	users, err := self.database.ListOnlineUsers(ctx, time.Now().Add(-onlineStaleThreshold))
+	if err != nil {
+		return nil, err
+	}
+	for _, user := range users {
+		user.Status = nil
+		user.Online = true
+	}
+	return userListResponse(users), nil
+}
+
+func (self *gateway) ListLocalOnlineUsers(ctx context.Context) (interface{}, error) {
+	// only the users connected to this node, taken from the live connection
+	// index, so a single id-set query fetches their records
+	users, err := self.database.GetUsers(ctx, self.connectedUserIds())
 	if err != nil {
 		return nil, err
 	}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -392,6 +392,20 @@ func (self *gateway) runOnlineHeartbeat(ctx context.Context) {
 			cancel()
 			if err != nil {
 				log.Warningf("failed to refresh online users: %s", err)
+				continue
+			}
+			// a user may have disconnected while the update was in flight,
+			// right after releaseUserNode cleared their node_id: the update
+			// would then have re-adopted them onto this node, so release
+			// everyone from the batch that is no longer connected
+			stillConnected := make(map[string]struct{}, len(userIds))
+			for _, userId := range self.connectedUserIds() {
+				stillConnected[userId] = struct{}{}
+			}
+			for _, userId := range userIds {
+				if _, ok := stillConnected[userId]; !ok {
+					self.releaseUserNode(userId)
+				}
 			}
 		}
 	}
@@ -417,12 +431,26 @@ func (self *gateway) releaseUserNode(userId string) {
 
 // userListResponse is the common shape of the user listing commands
 func userListResponse(users []*db.User) interface{} {
+	if users == nil {
+		// marshal an empty list as [] instead of null
+		users = []*db.User{}
+	}
 	return map[string]interface{}{
 		"users": users,
 		"meta": map[string]interface{}{
 			"totalCount": len(users),
 		},
 	}
+}
+
+// onlineUserListResponse strips the heavy status and marks every user
+// online, the common response shaping of the online listing commands
+func onlineUserListResponse(users []*db.User) interface{} {
+	for _, user := range users {
+		user.Status = nil
+		user.Online = true
+	}
+	return userListResponse(users)
 }
 
 func (self *gateway) ListUsers(ctx context.Context) (interface{}, error) {
@@ -452,11 +480,7 @@ func (self *gateway) ListOnlineUsers(ctx context.Context) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, user := range users {
-		user.Status = nil
-		user.Online = true
-	}
-	return userListResponse(users), nil
+	return onlineUserListResponse(users), nil
 }
 
 func (self *gateway) ListLocalOnlineUsers(ctx context.Context) (interface{}, error) {
@@ -466,11 +490,7 @@ func (self *gateway) ListLocalOnlineUsers(ctx context.Context) (interface{}, err
 	if err != nil {
 		return nil, err
 	}
-	for _, user := range users {
-		user.Status = nil
-		user.Online = true
-	}
-	return userListResponse(users), nil
+	return onlineUserListResponse(users), nil
 }
 
 func (self *gateway) GetUser(ctx context.Context, userId string) (interface{}, error) {
@@ -504,12 +524,6 @@ func (self *gateway) GetUser(ctx context.Context, userId string) (interface{}, e
 }
 
 func (self *gateway) GetUserScreenshot(ctx context.Context, userId string) ([]byte, error) {
-	user, err := self.database.GetUser(ctx, userId)
-	if err != nil {
-		return nil, err
-	}
-	if user == nil {
-		return nil, nil
-	}
-	return user.Screenshot, nil
+	// fetch only the blob instead of the whole row
+	return self.database.GetUserScreenshot(ctx, userId)
 }

--- a/gateway/service.go
+++ b/gateway/service.go
@@ -150,6 +150,8 @@ func (self *service) handleCommand(command []string) error {
 		return self.listUsers()
 	case len(command) == 1 && command[0] == "listOnlineUsers":
 		return self.listOnlineUsers()
+	case len(command) == 1 && command[0] == "listLocalOnlineUsers":
+		return self.listLocalOnlineUsers()
 	case len(command) == 2 && command[0] == "getUser":
 		return self.getUser(command[1])
 	}
@@ -175,6 +177,7 @@ func (self *service) help() error {
 			"    status [username] - show gateway status, optionally filter by username",
 			"    listUsers - list all users in database",
 			"    listOnlineUsers - list users that are currently online",
+			"    listLocalOnlineUsers - list users that are connected to this node",
 			"    getUser <username> - get details about a user from database",
 			"",
 		}...)
@@ -292,6 +295,14 @@ func (self *service) listUsers() error {
 
 func (self *service) listOnlineUsers() error {
 	output, err := self.connection.gateway.ListOnlineUsers(context.Background())
+	if err != nil {
+		return err
+	}
+	return self.marshal(output)
+}
+
+func (self *service) listLocalOnlineUsers() error {
+	output, err := self.connection.gateway.ListLocalOnlineUsers(context.Background())
 	if err != nil {
 		return err
 	}

--- a/gateway/service_integration_test.go
+++ b/gateway/service_integration_test.go
@@ -401,6 +401,13 @@ func TestGatewayListOnlineUsersMeshWide(t *testing.T) {
 	if node, ok := nodes["bob"]; !ok || node != "node-a" {
 		t.Fatalf("expected bob online on node-a, got %+v", nodes)
 	}
+
+	// listLocalOnlineUsers only reports users connected to this node: bob is
+	// on node-a, carol is online mesh-wide but connected to node-b only
+	local := parseUserList(t, bob, "listLocalOnlineUsers")
+	if local.Meta.TotalCount != 1 || local.Users[0].ID != "bob" || !local.Users[0].Online {
+		t.Fatalf("expected only bob connected locally, got %+v", local.Users)
+	}
 }
 
 // TestGatewayReleasesUserNodeOnDisconnect proves the user's node_id is


### PR DESCRIPTION

## Summary

Cuts normal-traffic database cost to one roundtrip per event — matters now
that sgwus reaches postgres over a ~170ms cross-region peer tunnel — and adds
a `listLocalOnlineUsers` command.

- auth: single `INSERT ON CONFLICT DO UPDATE RETURNING` upsert (was 4 roundtrips + full-row payload)
- `reportStatus`/`reportScreenshot`: targeted single-column updates (was 4 roundtrips dragging both blobs)
- mesh tunnel routing: fetches `node_id` only (was full row incl. screenshot)
- heartbeat folded into one statement; transaction wrappers dropped from single-statement reads
- `listLocalOnlineUsers` lists only users connected to the current node

<!-- changelog:start -->
### Added

- `listLocalOnlineUsers` shell command that lists users connected to the current node

### Changed

- Authentication, status reports and mesh routing lookups now cost a single
  database roundtrip instead of 3-4 with full-row payloads
<!-- changelog:end -->

## Test plan

- `TestUpsertUserOnConnect` (create/refresh/disabled-audit), `TestUpdateUserStatusAndScreenshot`,
  `TestGetUserNodeID`, `TestGetUsers`, `listLocalOnlineUsers` asserted in the mesh-wide test
- `make test` (postgres + `-race`), `make lint`, `make lint-mulint` all clean
