### PR TITLE
perf(db): keep the connection pool warm and bounded

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -22,6 +22,21 @@ import (
 
 var log = logging.MustGetLogger("db")
 
+const (
+	// pooled connections kept warm; establishing a connection through a peer
+	// tunnel costs several cross-region roundtrips (tcp, ssh handshake, tls,
+	// postgres auth), so the default pool of two idle connections makes
+	// bursty hot paths pay that setup cost over and over
+	maxIdleConnections = 8
+
+	// upper bound of connections each node opens, keeping its footprint on
+	// the shared postgres predictable; bursts queue on the pool instead
+	maxOpenConnections = 16
+
+	// how long an idle pooled connection is kept before being closed
+	connectionMaxIdleTime = 5 * time.Minute
+)
+
 type Database interface {
 	// migrate database schema
 	Migrate(context.Context) error
@@ -117,6 +132,13 @@ func Open(settings *Settings) (Database, error) {
 	if err != nil {
 		return nil, err
 	}
+	sqlDatabase, err := db.DB()
+	if err != nil {
+		return nil, err
+	}
+	sqlDatabase.SetMaxIdleConns(maxIdleConnections)
+	sqlDatabase.SetMaxOpenConns(maxOpenConnections)
+	sqlDatabase.SetConnMaxIdleTime(connectionMaxIdleTime)
 	self.db = db.Debug()
 	return self, nil
 }


### PR DESCRIPTION

## Summary

Remote mesh nodes showed SQL p50 ~5x the raw RTT: the default pool (2 idle,
unbounded open) makes bursty paths repeatedly pay the peer tunnel setup cost
(tcp + ssh + tls + postgres auth ≈ 1.5-2.5s), folded into whichever statement
triggered the dial.

- keep 8 idle connections warm, for up to 5 minutes
- cap open connections at 16 per node (4 nodes ≤ 64, postgres now at
  max_connections=200)

<!-- changelog:start -->
### Changed

- Database connection pool keeps idle connections warm and bounds open
  connections, avoiding repeated peer tunnel setup costs on remote nodes
<!-- changelog:end -->

## Test plan

- `make test` (postgres + `-race`), `make lint`, `make lint-mulint` all clean
- config-only change; the effect will be measured on the live mesh (expect
  remote SQL p50 to drop from ~850-980ms toward the ~1x RTT floor)
